### PR TITLE
logging access to system repos is now configurable

### DIFF
--- a/bcgithook/README.md
+++ b/bcgithook/README.md
@@ -19,6 +19,7 @@ This project offers a bash-based implementation for such git hooks.
 |`GIT_URL` | **required** | The URL to connect to the git repo. See below for examples for various Git repos. Surround the value in single quotation marks.|
 |`GIT_TYPE` | optional | Leave blank or undefined for all Git repos. Use **"azure"** (in quotation marks) for Azure DevOps |
 |`LOG_LOCATION` | optional | The directory where logs should be written. Defaults to `$HOME` |
+|`LOG_SYSTEM_REPOS` | optional | If set to "yes" will log access to system repositories, can result in some verbosity |
 
 See below for example configurations for various Git repos.
 

--- a/bcgithook/scripts/default.conf.example
+++ b/bcgithook/scripts/default.conf.example
@@ -1,4 +1,6 @@
 #
+# --- Configuration parameters ---
+#
 # GIT_TYPE      = "azure" for Azure, blank otherwise
 # GIT_USER_NAME = username for remote git repository
 # GIT_PASSWD    = password to connect to remote git repository
@@ -9,6 +11,13 @@
 #                   gitlab             https://gitlab.com/GIT_USER_NAME
 #                   github             https://github.com/GIT_USER_NAME
 #                   gitea (localhost)  http://localhost:3000/GIT_USER_NAME
+#
+#
+# LOG_LOCATION  = location of the bcgithook log file, default to $HOME
+#
+# LOG_SYSTEM_REPOS = [yes|no], set to "yes" to log access to PAM system
+#                              repositories, increases verbosity
+#
 #
 #
 # Uncomment and modify as appropriate
@@ -39,4 +48,5 @@
 # GIT_URL='http://localhost:3000/gitea_id'
 
 LOG_LOCATION=$HOME
+LOG_SYSTEM_REPOS=yes
 

--- a/bcgithook/scripts/post-commit.sh
+++ b/bcgithook/scripts/post-commit.sh
@@ -23,6 +23,9 @@
 # LOG_LOCATION  = were bcgithook log files should be stored, defaults to home directory of user
 #                 executing bcgithook post-commit
 #
+# LOG_SYSTEM_REPOS = [yes|no], set to "yes" to log access to PAM system
+#                              repositories, increases verbosity
+#
 #
 #GIT_USER_NAME='git_user_name'
 #GIT_PASSWD='git_password'
@@ -100,10 +103,10 @@ workpasswd=`urlencode "$gitPasswd"`
 
 # - ignore system repos
 hwd=`pwd` && hwd=${hwd#*\.niogit\/}
-frag=${hwd#system}       && [[ "$frag" != "$hwd" ]] && debug "SKIPPING BUILTIN PROJECT" && exit 0
-frag=${hwd#dashbuilder}  && [[ "$frag" != "$hwd" ]] && debug "SKIPPING BUILTIN PROJECT" && exit 0
-frag=${hwd#\.archetypes} && [[ "$frag" != "$hwd" ]] && debug "SKIPPING BUILTIN PROJECT" && exit 0
-frag=${hwd#*\.config}    && [[ "$frag" != "$hwd" ]] && debug "SKIPPING BUILTIN PROJECT" && exit 0
+frag=${hwd#system}       && [[ "$frag" != "$hwd" ]] && ( [[ "$LOG_SYSTEM_REPOS" != "yes" ]] || debug "SKIPPING BUILTIN PROJECT" ) && exit 0
+frag=${hwd#dashbuilder}  && [[ "$frag" != "$hwd" ]] && ( [[ "$LOG_SYSTEM_REPOS" != "yes" ]] || debug "SKIPPING BUILTIN PROJECT" ) && exit 0
+frag=${hwd#\.archetypes} && [[ "$frag" != "$hwd" ]] && ( [[ "$LOG_SYSTEM_REPOS" != "yes" ]] || debug "SKIPPING BUILTIN PROJECT" ) && exit 0
+frag=${hwd#*\.config}    && [[ "$frag" != "$hwd" ]] && ( [[ "$LOG_SYSTEM_REPOS" != "yes" ]] || debug "SKIPPING BUILTIN PROJECT" ) && exit 0
 
 addBBID=yes
 while read gitName gitUrl gitOps; do


### PR DESCRIPTION
Added configuration variable LOG_SYSTEM_REPOS to minimize logging while accessing PAM system repos.
Will result in less verbose logs that will contain operations performed only on user repositories/projects