### PR TITLE
adding support for DM 7.7.1 and other changes

### DIFF
--- a/pam-eap-setup/.gitignore
+++ b/pam-eap-setup/.gitignore
@@ -1,0 +1,4 @@
+**/*.zip
+go_pam.sh
+*.db
+pam/

--- a/pam-eap-setup/.gitignore
+++ b/pam-eap-setup/.gitignore
@@ -1,4 +1,4 @@
 **/*.zip
-go_pam.sh
+go_*.sh
 *.db
 pam/

--- a/pam-eap-setup/README.md
+++ b/pam-eap-setup/README.md
@@ -130,6 +130,7 @@ Depending on PAM version the following files are required:
         | 7.3.1    | rhdm-7.3.1-decision-central-eap7-deployable.zip, rhdm-7.3.1-kie-server-ee8.zip  |
         | 7.4.1    | rhdm-7.4.1-decision-central-eap7-deployable.zip, rhdm-7.4.1-kie-server-ee8.zip  |
         | 7.6.0    | rhdm-7.6.0-decision-central-eap7-deployable.zip, rhdm-7.6.0-kie-server-ee8.zip  |
+        | 7.7.1    | rhdm-7.7.1-decision-central-eap7-deployable.zip, rhdm-7.7.1-kie-server-ee8.zip  |
 
 ## Usage
 
@@ -143,6 +144,7 @@ Invoke with no arguments for usage info:
                              -b [kie|controller|both|multi=2...], defaults to 'both'
                              [-c ip1:port1,ip2:port2,...]
                              [-s smart_router_ip:port]
+                             [-o option1=value1[:option2=value2...]]
 
         example: pam-setup.sh -n localhost
 
@@ -172,7 +174,10 @@ Invoke with no arguments for usage info:
 
             -s : Only for KIE ES, optional. Specify Smart Router location, eg 10.10.1.23:9000
 
-            -o : Specify additional options. Supported options are:
+            -o : Specify additional options. To specify multiple options use ':' as separator. 
+                 Example: '-o option1=value1[:option2=value2:...]'
+
+                 Supported options are:
 
                  - nodeX_config=file : declare file with additional commands to be applied by
                                        EAPs jboss-cli tool for each node installed

--- a/pam-eap-setup/pam-setup.sh
+++ b/pam-eap-setup/pam-setup.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#^^^ make the script portable and ensure using a recent version of bash on macOS 
+# see more in https://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html
 
 #
 # - setup a local environment with BusinessCentral and one KIE Server
@@ -81,6 +83,7 @@ MASTER_CONFIG=master.conf
 #
 cat << "__CONFIG" > $MASTER_CONFIG
 PAM770 | EAP7_ZIP=jboss-eap-7.2.0.zip | EAP_PATCH_ZIP=jboss-eap-7.2.*-patch.zip | PAM_ZIP=rhpam-7.7.0-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.7.0-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.2 | TARGET_TYPE=PAM
+DM771  | EAP7_ZIP=jboss-eap-7.2.0.zip | EAP_PATCH_ZIP=jboss-eap-7.2.*-patch.zip | PAM_ZIP=rhdm-7.7.1-decision-central-eap7-deployable.zip  | KIE_ZIP=rhdm-7.7.1-kie-server-ee8.zip  | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.2 | TARGET_TYPE=DM
 DM760  | EAP7_ZIP=jboss-eap-7.2.0.zip | EAP_PATCH_ZIP=jboss-eap-7.2.*-patch.zip | PAM_ZIP=rhdm-7.6.0-decision-central-eap7-deployable.zip  | KIE_ZIP=rhdm-7.6.0-kie-server-ee8.zip  | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.2 | TARGET_TYPE=DM
 PAM760 | EAP7_ZIP=jboss-eap-7.2.0.zip | EAP_PATCH_ZIP=jboss-eap-7.2.*-patch.zip | PAM_ZIP=rhpam-7.6.0-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.6.0-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.2 | TARGET_TYPE=PAM
 PAM751 | EAP7_ZIP=jboss-eap-7.2.0.zip | EAP_PATCH_ZIP=jboss-eap-7.2.*-patch.zip | PAM_ZIP=rhpam-7.5.1-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.5.1-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.2 | TARGET_TYPE=PAM


### PR DESCRIPTION
Tested in macOS. As macOS comes with an old version of `bash` in `/bin/bash` its recommended to use the env shebash as suggested here: https://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html. Thus the script can use the correct version of bash on MacOS.