### PR TITLE
Changed pam examples bash shebangs to use env

### DIFF
--- a/pam-quick-examples/dmn-example1/build.sh
+++ b/pam-quick-examples/dmn-example1/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 EXAMPLE_PATH="$(cd "$(dirname "$0")" && pwd)"
 EXAMPLE_ID="$(basename $EXAMPLE_PATH)"
 

--- a/pam-quick-examples/dmn-example1/run.sh
+++ b/pam-quick-examples/dmn-example1/run.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 EXAMPLE_PATH="$(cd "$(dirname "$0")" && PWD)"
 EXAMPLE_ID="$(basename $EXAMPLE_PATH)"
 

--- a/pam-quick-examples/dmn-example2/build.sh
+++ b/pam-quick-examples/dmn-example2/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 EXAMPLE_PATH="$(cd "$(dirname "$0")" && pwd)"
 EXAMPLE_ID="$(basename $EXAMPLE_PATH)"
 

--- a/pam-quick-examples/dmn-example2/run.sh
+++ b/pam-quick-examples/dmn-example2/run.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 EXAMPLE_PATH="$(cd "$(dirname "$0")" && PWD)"
 EXAMPLE_ID="$(basename $EXAMPLE_PATH)"
 

--- a/pam-quick-examples/dmn-example3/build.sh
+++ b/pam-quick-examples/dmn-example3/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 EXAMPLE_PATH="$(cd "$(dirname "$0")" && pwd)"
 EXAMPLE_ID="$(basename $EXAMPLE_PATH)"
 

--- a/pam-quick-examples/dmn-example3/run.sh
+++ b/pam-quick-examples/dmn-example3/run.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 EXAMPLE_PATH="$(cd "$(dirname "$0")" && PWD)"
 EXAMPLE_ID="$(basename $EXAMPLE_PATH)"
 

--- a/pam-quick-examples/dmn-example4/build.sh
+++ b/pam-quick-examples/dmn-example4/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 EXAMPLE_PATH="$(cd "$(dirname "$0")" && pwd)"
 EXAMPLE_ID="$(basename $EXAMPLE_PATH)"
 

--- a/pam-quick-examples/dmn-example4/run.sh
+++ b/pam-quick-examples/dmn-example4/run.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 EXAMPLE_PATH="$(cd "$(dirname "$0")" && PWD)"
 EXAMPLE_ID="$(basename $EXAMPLE_PATH)"
 

--- a/pam-quick-examples/dmn-example5/build.sh
+++ b/pam-quick-examples/dmn-example5/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 EXAMPLE_PATH="$(cd "$(dirname "$0")" && pwd)"
 EXAMPLE_ID="$(basename $EXAMPLE_PATH)"
 

--- a/pam-quick-examples/dmn-example5/run.sh
+++ b/pam-quick-examples/dmn-example5/run.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 EXAMPLE_PATH="$(cd "$(dirname "$0")" && pwd)"
 EXAMPLE_ID="$(basename $EXAMPLE_PATH)"
 

--- a/pam-quick-examples/dmn-example6/build.sh
+++ b/pam-quick-examples/dmn-example6/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 EXAMPLE_PATH="$(cd "$(dirname "$0")" && pwd)"
 EXAMPLE_ID="$(basename $EXAMPLE_PATH)"
 

--- a/pam-quick-examples/dmn-example6/run.sh
+++ b/pam-quick-examples/dmn-example6/run.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 EXAMPLE_PATH="$(cd "$(dirname "$0")" && pwd)"
 EXAMPLE_ID="$(basename $EXAMPLE_PATH)"
 


### PR DESCRIPTION
#### What is this PR About?
Makes the scripts a bit more env friendly across linux/mac with multiple bash versions installed

cc: @redhat-cop/businessautomation-cop
