### PR TITLE
fix for potentially malhandling of jvm_memory option

### DIFF
--- a/pam-eap-setup/pam-setup.sh
+++ b/pam-eap-setup/pam-setup.sh
@@ -998,7 +998,7 @@ if [ "$skip_install" != "yes" ]; then
       nodeConfig['nodeOffset']=$nodeOffset
       nodeConfig['nodePort']=$nodePort
       nodeConfig['eap_location']="$EAP_LOCATION"
-      jvm_memory=${configOptions[jvm_memory]} && [[ ! -z "jvm_memory" ]] && nodeConfig['jvm_memory']="$jvm_memory"
+      jvm_memory=${configOptions[jvm_memory]} && [[ ! -z "$jvm_memory" ]] && nodeConfig['jvm_memory']="$jvm_memory"
       sout "Installing ${bold}${blue}node${node}${normal} as ${bold}${blue}${nodeConfig[nodeName]}${normal}"
       summary "--- Node instalation node${node} as $nodeParam : ${nodeConfig[nodeName]}"
       ( [[ "$pamInstall" == "controller" ]] || [[ "$pamInstall" == "both" ]] ) && installBC && nodeConfig['pamInstall']="${nodeConfig['pamInstall']} controller"


### PR DESCRIPTION
#### What is this PR About?
Fixing handling of options parameter. 
Potentially could ignore provided options for jvm_memory

#### How do we test this?
Run ./pam-setup.sh without providing "jvm_memory" option. Defaults should be used.

cc: @redhat-cop/businessautomation-cop
