### PR TITLE
Added shellcheck to pam-examples ci

### DIFF
--- a/.github/workflows/mvn-pam-quick-examples.yaml
+++ b/.github/workflows/mvn-pam-quick-examples.yaml
@@ -36,6 +36,11 @@ jobs:
           repositories: '[{ "id": "redhat-ga-repository", "url": "https://maven.repository.redhat.com/ga" }]'
           plugin_repositories: '[{ "id": "redhat-ga-repository", "url": "https://maven.repository.redhat.com/ga" }]'
 
+      - name: Run ShellCheck
+        uses: garethahealy/action-shellcheck@master
+        with:
+          ignore: bcgithook bdd-ui kogito-quick-start-workshop offliner-maven-plugin pam-eap-setup
+
       - name: Build pam-quick-examples
         run: |
           pushd pam-quick-examples/dmn-example1

--- a/pam-quick-examples/dmn-example4/run.sh
+++ b/pam-quick-examples/dmn-example4/run.sh
@@ -80,7 +80,7 @@ function start_test(){
     if [[ $EXAMPLE_CONFIGURATION == *"remote"* ]]; then
         deploy_kjars
     fi
-    echo $POM_ABSOLUTE_PATH
+    echo "$POM_ABSOLUTE_PATH"
     echo "$MAVEN_PARAMETERS"
     mvn test -f "$POM_ABSOLUTE_PATH" "$MAVEN_PARAMETERS"
     echo "=================== End execution of tests ==================="


### PR DESCRIPTION
#### What is this PR About?
Adds shellcheck directly under pam examples. Currently it uses a fork of the shellcheck under my repo, as i need this PR merging:
- https://github.com/ludeeus/action-shellcheck/pull/15

So expect another PR in the future once they merge, and we can move back to upstream

cc: @redhat-cop/businessautomation-cop
