### PR TITLE
Added other OS images for bcgithook / pam-eap-setup ci

### DIFF
--- a/.github/workflows/build-bcgithook.yaml
+++ b/.github/workflows/build-bcgithook.yaml
@@ -12,12 +12,19 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Run ShellCheck
+        if: matrix.os == 'ubuntu-latest'
         uses: ludeeus/action-shellcheck@master
         with:
           ignore: bdd-ui kogito-quick-start-workshop offliner-maven-plugin pam-eap-setup pam-quick-examples

--- a/.github/workflows/build-pam-eap-setup.yaml
+++ b/.github/workflows/build-pam-eap-setup.yaml
@@ -12,12 +12,19 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Run ShellCheck
+        if: matrix.os == 'ubuntu-latest'
         uses: ludeeus/action-shellcheck@master
         with:
           ignore: bcgithook bdd-ui kogito-quick-start-workshop offliner-maven-plugin pam-quick-examples


### PR DESCRIPTION
#### What is this PR About?
Adds other OS's as test platforms. Should allow for platform testing of the below in the future:
- https://github.com/redhat-cop/businessautomation-cop/pull/108

#### How do we test this?
Check action output

cc: @redhat-cop/businessautomation-cop