### PR TITLE
Added ansible to download eap zip for pam-eap-setup

### DIFF
--- a/.github/actions/eap-base/Dockerfile
+++ b/.github/actions/eap-base/Dockerfile
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
+
+LABEL version="1.0.0"
+LABEL repository="https://github.com/redhat-cop/businessautomation-cop"
+LABEL homepage="https://github.com/redhat-cop/businessautomation-cop"
+LABEL maintainer="Red Hat CoP"
+LABEL "com.github.actions.name"="eap-base"
+LABEL "com.github.actions.description"="Action to run Red Hat EAP"
+LABEL "com.github.actions.branding.icon"="monitor"
+LABEL "com.github.actions.branding.color"="purple"
+
+RUN microdnf install --assumeyes --nodocs tar wget git zip java-1.8.0-openjdk sqlite findutils && \
+    microdnf clean all
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/eap-base/action.yml
+++ b/.github/actions/eap-base/action.yml
@@ -1,0 +1,20 @@
+name: 'eap-base'
+description: 'Action to run Red Hat EAP'
+author: 'Red Hat CoP'
+branding:
+  icon: monitor
+  color: purple
+inputs:
+  should_run:
+    description: "If this is empty, the action is skipped."
+    required: false
+  command:
+    description: "Command to exec"
+    required: true
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.should_run }}
+    - ${{ inputs.command }}

--- a/.github/actions/eap-base/entrypoint.sh
+++ b/.github/actions/eap-base/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+SHOULD_RUN=$1
+CMD=$2
+
+if [ -z "${SHOULD_RUN}" ]
+then
+  echo "SHOULD_RUN is empty. Skipping."
+  exit 0
+fi
+
+echo "Executing: $CMD"
+eval "$CMD"

--- a/.github/workflows/build-pam-eap-setup.yaml
+++ b/.github/workflows/build-pam-eap-setup.yaml
@@ -23,6 +23,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: redhat-csp-download
+        if: matrix.os == 'ubuntu-latest'
+        uses: garethahealy/github-actions/redhat-csp-download@master
+        with:
+          rh_username: ${{ secrets.RH_USERNAME }}
+          rh_password: ${{ secrets.RH_PASSWORD }}
+          download: '[{"file":"/github/workspace/pam-eap-setup/jboss-eap-7.2.0.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=64311"},{"file":"/github/workspace/pam-eap-setup/rhpam-7.7.1-business-central-eap7-deployable.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=82441"},{"file":"/github/workspace/pam-eap-setup/rhpam-7.7.1-kie-server-ee8.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=82291"}]'
+
+      - name: Run pam-setup.sh
+        if: matrix.os == 'ubuntu-latest'
+        uses: ./.github/actions/eap-base
+        with:
+          should_run: ${{ secrets.RH_USERNAME }}
+          command: "cd pam-eap-setup; ./pam-setup.sh; rm -rf pam"
+
       - name: Run ShellCheck
         if: matrix.os == 'ubuntu-latest'
         uses: ludeeus/action-shellcheck@master


### PR DESCRIPTION
#### What is this PR About?
Downloads all the product zips needed by pam-eap-setup.sh and then executes the script to check its worked.

NOTE: As it uses secrets, future PRs won't be tested unless the raiser adds the required secrets to their fork.

#### How do we test this?
My fork with creds: https://github.com/garethahealy/businessautomation-cop/runs/806824005?check_suite_focus=true
This PR without creds: https://github.com/redhat-cop/businessautomation-cop/pull/136/checks?check_run_id=806873240

cc: @redhat-cop/businessautomation-cop
