### PR TITLE
removed CI badges from READMEs, badges not accurate at the moment

### DIFF
--- a/bcgithook/README.md
+++ b/bcgithook/README.md
@@ -1,5 +1,4 @@
-﻿![Build for bcgithook](https://github.com/redhat-cop/businessautomation-cop/workflows/Build%20for%20bcgithook/badge.svg)
-
+﻿
 # bcgithook: Business Central git hooks in bash
 Business Central is able to push changes into remote git repositories utilizing post-commit git hooks.
 This project offers a bash-based implementation for such git hooks.

--- a/pam-eap-setup/README.md
+++ b/pam-eap-setup/README.md
@@ -1,4 +1,3 @@
-![Build for pam-eap-setup](https://github.com/redhat-cop/businessautomation-cop/workflows/Build%20for%20pam-eap-setup/badge.svg)
 
 # pam-setup
 


### PR DESCRIPTION
#### What is this PR About?
CI badges for pam-eap-setup and bcgithook not accurate and have been removed.
CI resuls skewed be shellchekc's inaccurate suggestions.

#### How do we test this?
No changes to code.

cc: @redhat-cop/businessautomation-cop
