### PR TITLE
Add RegEx handling to the BRANCH_ALLOW variable.

### DIFF
--- a/bcgithook/README.md
+++ b/bcgithook/README.md
@@ -23,8 +23,9 @@ This project offers a bash-based implementation for such git hooks.
 |`GIT_TYPE` | optional | Leave blank or undefined for all Git repos. Use **"azure"** (in quotation marks) for Azure DevOps |
 |`LOG_LOCATION` | optional | The directory where logs should be written. Defaults to `$HOME` |
 |`LOG_SYSTEM_REPOS` | optional | If set to "yes" will log access to system repositories, can result in some verbosity |
-|`BRANCH_ALLOW`| optional | A comma-separated list of branches to allow commits to be pushed to. Do not leave space between the comma and the branch name or enclose in quotes |
-|`BRANCH_DENY`| optional | a comma-separated list of branches to deny commits to be pushed to. Do not leave space between the comma and and the branch name or enclose in quotes. |
+|`BRANCH_ALLOW`| optional | A comma-separated list, or a regular expession, of branches to allow commits to be pushed to.  When using a comma-separated list of branches, do not leave space between the comma and the branch name or enclose in quotes.  When using a regular expression, set the BRANCH_ALLOW_IS_REGEX variable to true, and enclose with quotes. |
+|`BRANCH_DENY`| optional | a comma-separated list of branches to deny commits to be pushed to. Do not leave space between the comma and the branch name or enclose in quotes. |
+|`BRANCH_ALLOW_IS_REGEX`| optional | default behavior is false, set to true when the BRANCH_ALLOW field contains a regular expression instead of a comma-separated list of branches. |
 
 See below for example configurations for various Git repos.
 
@@ -53,6 +54,13 @@ ALLOW and DENY lists refer to branches that the post-commit git hooks will selec
 |`BRANCH_ALLOW=branch2,feature/fa`|Commits in branch "feature/fa" will be pushed to the remote git repo. Branch "branch2" is also declared at `BRANCH_DENY` which takes precedence.|
 |`BRANCH_DENY=master,release,branch2`|Commits in branches "master", "release" and "branch2" will not be pushed to the remote git repo.|
 
+**Example 3: Separate branches in ALLOW and DENY lists, with regular expressions**
+
+| Definition | Expected Action
+|-|-|
+|`BRANCH_ALLOW_IS_REGEX=true`|Specifies that the BRANCH_ALLOW variable contains a regular expression, which is not a comma-separated list of strings.|
+|`BRANCH_ALLOW="^(branch2)|(feature/fa)$`|Commits in branches "branch2" and "feature/fa" will be pushed to the remote git repo.|
+|`BRANCH_DENY=master,release`|Commits in branches "master" and "release" will not be pushed to the remote git repo.|
 
 ### per-project configuration
 **bcgithook** allows for different configuration per-project. For this to happen a file with the same name as the project having the `.conf` suffix should be placed in `$HOME/.bcgithook` directory. `default.conf` can be used as a template however only values that are different from `default.conf` need to be defined. For example, a project named "FormApplicationProcess" would use the `FormApplicationProcess.conf` configuration file if that file is found.

--- a/bcgithook/scripts/default.conf.example
+++ b/bcgithook/scripts/default.conf.example
@@ -20,9 +20,10 @@
 #
 # BRANCH_DENY=master,release
 # BRANCH_ALLOW=br2,feature/fa
+# BRANCH_ALLOW_IS_REGEX = [true|false], default false, set to "true" when the BRANCH_ALLOW field contains a regular expression
 #
 # Optional allow and deny list for branches
-# Specify a comma-separated list of branches
+# Specify a comma-separated list of branches, or a regular-expression when the BRANCH_ALLOW_IS_REGEX flag is true.  Use quotes when using regular expressions
 #
 #  - if BRANCH_ALLOW exists, only commits in branches in the list will be pushed to the remote repo
 #  - if BRANCH_DENY exists, commits in branches in the list will not be pushed to the remote repo
@@ -41,6 +42,11 @@
 # Commits in branches "feature/fa" will be pushed to remote repo
 # Commits in branches "master", "release" and "branch2" will not be pushed to remote repo
 #
+# (c)
+# - BRANCH_ALLOW_IS_REGEX=true
+# - BRANCH_ALLOW="^(branch2)|(feature/fa)$"
+# - BRANCH_DENY=master,release
+# Results in the same behavior as example (a) above, but with Regular Expressions
 #
 # Uncomment and modify as appropriate
 #

--- a/bcgithook/scripts/post-commit.sh
+++ b/bcgithook/scripts/post-commit.sh
@@ -188,7 +188,7 @@ debug "PUSHING TO $remoteGitUrl"
 # git push -u $BBID --all 
 for bru in $bruli; do
   deny=no 
-  [[ -n "$BRANCH_ALLOW" ]] && deny=yes && for de in ${BRANCH_ALLOW//,/ }; do [[ "$de" == "$bru" ]] && deny=no; done
+  [[ -n "$BRANCH_ALLOW" ]] && deny=yes &&  if [ "$BRANCH_ALLOW_IS_REGEX" = true ] ; then [[ "$bru" =~ $BRANCH_ALLOW ]] && deny=no; else for de in ${BRANCH_ALLOW//,/ }; do [[ "$de" == "$bru" ]] && deny=no; done fi
   for de in ${BRANCH_DENY//,/ }; do [[ "$de" == "$bru" ]] && deny=yes; done
   if [[ "$deny" == "yes" ]]; then
     debug "COMMITS TO BRANCH [$bru] ARE NOT ALLOWED - COMMIT NOT PUSHED TO $remoteGitUrl"


### PR DESCRIPTION
- Adds flag to enable regex mode
- Updates documentation and README
- Adds example configuration

#### What is this PR About?
This PR adds the ability to specify a regular expression for the BRANCH_ALLOW variable.

#### How do we test this?
There are 8 scenarios to test for, which can probably be better visualized as a truth table.

BRANCH_ALLOW_IS_REGEX=true
BRANCH_ALLOW=csv
BRANCH_DENY=non-empty

BRANCH_ALLOW_IS_REGEX=true
BRANCH_ALLOW=csv
BRANCH_DENY=empty

BRANCH_ALLOW_IS_REGEX=true
BRANCH_ALLOW=regex
BRANCH_DENY=non-empty

BRANCH_ALLOW_IS_REGEX=true
BRANCH_ALLOW=regex
BRANCH_DENY=empty

BRANCH_ALLOW_IS_REGEX=false
BRANCH_ALLOW=csv
BRANCH_DENY=non-empty

BRANCH_ALLOW_IS_REGEX=false
BRANCH_ALLOW=csv
BRANCH_DENY=empty

BRANCH_ALLOW_IS_REGEX=false
BRANCH_ALLOW=regex
BRANCH_DENY=non-empty

BRANCH_ALLOW_IS_REGEX=false
BRANCH_ALLOW=regex
BRANCH_DENY=empty


cc: @redhat-cop/businessautomation-cop
