### PR TITLE
Refactoring branch handling with regexes in BC git hooks

### DIFF
--- a/bcgithook/README.md
+++ b/bcgithook/README.md
@@ -23,9 +23,9 @@ This project offers a bash-based implementation for such git hooks.
 |`GIT_TYPE` | optional | Leave blank or undefined for all Git repos. Use **"azure"** (in quotation marks) for Azure DevOps |
 |`LOG_LOCATION` | optional | The directory where logs should be written. Defaults to `$HOME` |
 |`LOG_SYSTEM_REPOS` | optional | If set to "yes" will log access to system repositories, can result in some verbosity |
-|`BRANCH_ALLOW`| optional | A comma-separated list, or a regular expession, of branches to allow commits to be pushed to.  When using a comma-separated list of branches, do not leave space between the comma and the branch name or enclose in quotes.  When using a regular expression, set the BRANCH_ALLOW_IS_REGEX variable to true, and enclose with quotes. |
+|`BRANCH_ALLOW`| optional | A comma-separated list, or a regular expession, of branches to allow commits to be pushed to.  When using a comma-separated list of branches, do not leave space between the comma and the branch name or enclose in quotes. |
+|`BRANCH_ALLOW_REGEX`| optional | A regular expression specifying branches to allow commits for. If defined overrides `BRANCH_ALLOW`. Use quotes to specify a regular expression, for example `"^(feature/)|^(hotfix)"` |
 |`BRANCH_DENY`| optional | a comma-separated list of branches to deny commits to be pushed to. Do not leave space between the comma and the branch name or enclose in quotes. |
-|`BRANCH_ALLOW_IS_REGEX`| optional | default behavior is false, set to true when the BRANCH_ALLOW field contains a regular expression instead of a comma-separated list of branches. |
 
 See below for example configurations for various Git repos.
 
@@ -35,10 +35,11 @@ Post-commit git hooks by default will push all commits in a branch to the config
 ALLOW and DENY lists refer to branches that the post-commit git hooks will selectively push commits to according to the following rules:
 
 * Both lists are optional. You can define either ALLOW or DENY, both or none.
+* If present, ALLOW_REGEX will override ALLOW.
 * If no list is defined post-commit git hooks will by default allow all commits to be pushed to the remote git repo.
-* If only the ALLOW list is defined, commits will be pushed to the remote git repo only for branches that can be found in this list.
+* If only the ALLOW (or ALLOW_REGEX) list is defined, commits will be pushed to the remote git repo only for branches that can be found in this list.
 * If only the DENY list is defined, commits to branches that can be found in this list will NOT be pushed to the remote git repo.
-* If both ALLOW and DENY lists are defined, then the DENY list takes precedence. If a branch can be found at both the ALLOW and DENY lists, then commits to that branch will not be pushed to the remote git repo.
+* If both ALLOW (or ALLOW_REGEX) and DENY lists are defined, then the DENY list takes precedence. If a branch can be found at both the ALLOW (or ALLOW_REGEX) and DENY lists, then commits to that branch will not be pushed to the remote git repo.
 
 **Example 1: Separate branches in ALLOW and DENY lists**
 
@@ -58,9 +59,9 @@ ALLOW and DENY lists refer to branches that the post-commit git hooks will selec
 
 | Definition | Expected Action
 |-|-|
-|`BRANCH_ALLOW_IS_REGEX=true`|Specifies that the BRANCH_ALLOW variable contains a regular expression, which is not a comma-separated list of strings.|
-|`BRANCH_ALLOW="^(branch2)|(feature/fa)$`|Commits in branches "branch2" and "feature/fa" will be pushed to the remote git repo.|
-|`BRANCH_DENY=master,release`|Commits in branches "master" and "release" will not be pushed to the remote git repo.|
+|`BRANCH_ALLOW_REGEX="^(hotfix/)|^(feature/)"`| Specifies branches to allow commits for in the form of regular expressions. In this example commits in branches starting with `hotfix/` or `feature/` will be allowed to be pushed to the remote git repo |
+|`BRANCH_ALLOW="branch2,feature/fa"`| This variable is overriden by `BRANCH_ALLOW_REGEX` and will be ignored |
+|`BRANCH_DENY=master,release`| Commits in branches "master" and "release" will not be pushed to the remote git repo.|
 
 ### per-project configuration
 **bcgithook** allows for different configuration per-project. For this to happen a file with the same name as the project having the `.conf` suffix should be placed in `$HOME/.bcgithook` directory. `default.conf` can be used as a template however only values that are different from `default.conf` need to be defined. For example, a project named "FormApplicationProcess" would use the `FormApplicationProcess.conf` configuration file if that file is found.
@@ -91,7 +92,7 @@ Please execute the `install.sh` script providing the directory of your [JBoss EA
 
 ## Notes on Git Repos
 ### GitLab
-Pushing to GitLab works without any additional configuration. 
+Pushing to GitLab works without any additional configuration.
 When a project is created in Business Central it will be pushed to a same-named repository to Gitlab.
 
 Example configuration:

--- a/bcgithook/README.md
+++ b/bcgithook/README.md
@@ -24,7 +24,7 @@ This project offers a bash-based implementation for such git hooks.
 |`LOG_LOCATION` | optional | The directory where logs should be written. Defaults to `$HOME` |
 |`LOG_SYSTEM_REPOS` | optional | If set to "yes" will log access to system repositories, can result in some verbosity |
 |`BRANCH_ALLOW`| optional | A comma-separated list, or a regular expession, of branches to allow commits to be pushed to.  When using a comma-separated list of branches, do not leave space between the comma and the branch name or enclose in quotes. |
-|`BRANCH_ALLOW_REGEX`| optional | A regular expression specifying branches to allow commits for. If defined overrides `BRANCH_ALLOW`. Use quotes to specify a regular expression, for example `"^(feature/)|^(hotfix)"` |
+|`BRANCH_ALLOW_REGEX`| optional | A regular expression specifying branches to allow commits for. If defined overrides `BRANCH_ALLOW`. Use quotes to specify a regular expression, for example `"^(feature/)\|^(hotfix)"` |
 |`BRANCH_DENY`| optional | a comma-separated list of branches to deny commits to be pushed to. Do not leave space between the comma and the branch name or enclose in quotes. |
 
 See below for example configurations for various Git repos.
@@ -59,7 +59,7 @@ ALLOW and DENY lists refer to branches that the post-commit git hooks will selec
 
 | Definition | Expected Action
 |-|-|
-|`BRANCH_ALLOW_REGEX="^(hotfix/)|^(feature/)"`| Specifies branches to allow commits for in the form of regular expressions. In this example commits in branches starting with `hotfix/` or `feature/` will be allowed to be pushed to the remote git repo |
+|`BRANCH_ALLOW_REGEX="^(hotfix/)\|^(feature/)"`| Specifies branches to allow commits for in the form of regular expressions. In this example commits in branches starting with `hotfix/` or `feature/` will be allowed to be pushed to the remote git repo |
 |`BRANCH_ALLOW="branch2,feature/fa"`| This variable is overriden by `BRANCH_ALLOW_REGEX` and will be ignored |
 |`BRANCH_DENY=master,release`| Commits in branches "master" and "release" will not be pushed to the remote git repo.|
 

--- a/bcgithook/scripts/default.conf.example
+++ b/bcgithook/scripts/default.conf.example
@@ -20,14 +20,16 @@
 #
 # BRANCH_DENY=master,release
 # BRANCH_ALLOW=br2,feature/fa
-# BRANCH_ALLOW_IS_REGEX = [true|false], default false, set to "true" when the BRANCH_ALLOW field contains a regular expression
+# BRANCH_ALLOW_REGEX="^(hotfix/)|^(feature/)"
 #
 # Optional allow and deny list for branches
-# Specify a comma-separated list of branches, or a regular-expression when the BRANCH_ALLOW_IS_REGEX flag is true.  Use quotes when using regular expressions
+# Specify a comma-separated list of branches, or a regular-expression. Use quotes when using regular expressions
 #
 #  - if BRANCH_ALLOW exists, only commits in branches in the list will be pushed to the remote repo
+#  - if BRANCH_ALLOW_REGEX exists, it will override BRANCH_ALLOW and
+#    branches will be committed only if they match the regular expression
 #  - if BRANCH_DENY exists, commits in branches in the list will not be pushed to the remote repo
-#  - if both lists exist, BRANCH_DENY takes precedene
+#  - BRANCH_DENY always takes precedene if it exists
 #
 # Example:
 # (a)
@@ -43,10 +45,12 @@
 # Commits in branches "master", "release" and "branch2" will not be pushed to remote repo
 #
 # (c)
-# - BRANCH_ALLOW_IS_REGEX=true
-# - BRANCH_ALLOW="^(branch2)|(feature/fa)$"
+# - BRANCH_ALLOW=devel
+# - BRANCH_ALLOW_REGEX="^(hotfix/)|^(feature/)"
 # - BRANCH_DENY=master,release
-# Results in the same behavior as example (a) above, but with Regular Expressions
+# Commits in branches "master" and "release" will not be pused to remote repo
+# Commits in branch "devel" will not be pused to remote repo as BRANCH_ALLOW_REGEX overrides BRANCH_ALLOW
+# Only commits in branches starting with "hotfix/" or "feature/" will be pused to remote repo
 #
 # Uncomment and modify as appropriate
 #
@@ -54,22 +58,22 @@
 # GIT_USER_NAME='bitbucket_id'
 # GIT_PASSWD='passwd'
 # GIT_URL='https://bitbucket_id@bitbucket.org/bitbucket_id'
-# 
+#
 # GIT_TYPE="azure"
 # GIT_USER_NAME='azure_id'
 # GIT_PASSWD='passwd'
 # GIT_URL='https://azure_id@dev.azure.com/azure_id/organisation_or_project/_git'
-# 
+#
 # GIT_TYPE=""
 # GIT_USER_NAME='github_id'
 # GIT_PASSWD='passwd'
 # GIT_URL='https://github.com/github_id'
-# 
+#
 # GIT_TYPE=""
 # GIT_USER_NAME='gitlab_id'
 # GIT_PASSWD='passwd'
 # GIT_URL='https://gitlab.com/gitlab_id'
-# 
+#
 # GIT_TYPE=""
 # GIT_USER_NAME='gitea_id'
 # GIT_PASSWD='passwd'
@@ -77,7 +81,8 @@
 #
 # BRANCH_DENY=master,release
 # BRANCH_ALLOW=br2,feature/fa
-# 
+# BRANCH_ALLOW_REGEX="^(hotfix/)|^(feature)"
+#
 
 LOG_LOCATION=$HOME
 LOG_SYSTEM_REPOS=yes


### PR DESCRIPTION
#### What is this PR About?
Refactoring application of regular expressions to the handling of branches in BC post-commit git hooks.
This implementation does not use the same variable for regex and non-regex cases making it easier to keep track of applicable conditions.
Documentation updated

#### How do we test this?
Simplifies testing by having only ALLOW and DENY lists to check,
Regexes are handled the same as ALLOW.

cc: @redhat-cop/businessautomation-cop
