### PR TITLE
refactored checks to apply only when called for

### DIFF
--- a/pam-eap-setup/pam-setup.sh
+++ b/pam-eap-setup/pam-setup.sh
@@ -44,9 +44,9 @@ command -v grep &> /dev/null     || { echo >&2 'ERROR: grep not installed. Pleas
 command -v awk &> /dev/null      || { echo >&2 'ERROR: awk not installed. Please install awk to continue - Aborting'; exit 1; }
 command -v basename &> /dev/null || { echo >&2 'ERROR: basename not installed. Please install basename to continue - Aborting'; exit 1; }
 # required to checkout and built dependencies
-command -v curl &> /dev/null     || { echo >&2 'ERROR: curl not installed. Please install curl to continue - Aborting'; exit 1; }
-command -v git &> /dev/null     || { echo >&2 'ERROR: GIT not installed. Please install GIT.1.8 (or later) to continue - Aborting'; exit 1; }
-command -v mvn &> /dev/null     || { echo >&2 'ERROR: MAVEN not installed. Please install MAVEN.3.6.2 (or later) to continue - Aborting'; exit 1; }
+# command -v curl &> /dev/null     || { echo >&2 'ERROR: curl not installed. Please install curl to continue - Aborting'; exit 1; }
+# command -v git &> /dev/null     || { echo >&2 'ERROR: GIT not installed. Please install GIT.1.8 (or later) to continue - Aborting'; exit 1; }
+# command -v mvn &> /dev/null     || { echo >&2 'ERROR: MAVEN not installed. Please install MAVEN.3.6.2 (or later) to continue - Aborting'; exit 1; }
 
 # - check mvn version
 #mvnVersion=$(mvn -version | head -1 | awk '{print $3}' | tr -d '.')
@@ -195,6 +195,13 @@ function waitForKey() {
   echo
   read -r -p 'Press ENTER key to continue...'
   echo
+}
+
+function checkEnv() {
+  local sw="$1"
+  [[ "$sw" == "curl" ]] && ( command -v curl &> /dev/null || { echo >&2 'ERROR: curl not installed. Please install curl to continue - Aborting'; exit 1; } )
+  [[ "$sw" == "git" ]]  && ( command -v git &> /dev/null  || { echo >&2 'ERROR: GIT not installed. Please install GIT.1.8 (or later) to continue - Aborting'; exit 1; } )
+  [[ "$sw" == "mvn" ]]  && ( command -v mvn &> /dev/null  || { echo >&2 'ERROR: MAVEN not installed. Please install MAVEN.3.6.2 (or later) to continue - Aborting'; exit 1; } )
 }
 
 declare -a summaryAr
@@ -1077,6 +1084,8 @@ if [[ ! -z "$optO" ]]; then
   configOptions[run_mode]="development"
   [[ "$tmp" == "production" ]] && configOptions[run_mode]="$tmp"
   unset tmp tmpar multiOptions
+  [[ "${configOptions[git_hook]}" == "bcgithook" ]] && checkEnv git && checkEnv curl
+  [[ "${configOptions[git_hook]}" == "kiegroup" ]] && checkEnv git && checkEnv curl && checkEnv mvn
 fi
 #
 [[ ! -r $EAP7_ZIP ]]      && sout "ERROR: Cannot read EAP.7 ZIP file $EAP7_ZIP -- exiting"          && exit 1;


### PR DESCRIPTION
#### What is this PR About?
pam-eap-setup checks for git, curl and maven are only needed for specific installation options. Checks for these have been refactored to be applied only when these installation options are specified.

#### How do we test this?
Should install without git, curl or maven if no git hook option is specified

cc: @redhat-cop/businessautomation-cop
