### PR TITLE
fixed regression on empty installation path

### DIFF
--- a/pam-eap-setup/CHANGELOG
+++ b/pam-eap-setup/CHANGELOG
@@ -1,6 +1,11 @@
 
 # CHANGELOG
 
+-- RELEASE: 5 AUGUST 2020
+
+PAM: Updated for PAM.7.8
+PAM: Added PostgreSQL support
+
 -- RELEASE: 25 JULY 2020
 
 PAM: Added post-commit git hooks integration

--- a/pam-eap-setup/pam-setup.sh
+++ b/pam-eap-setup/pam-setup.sh
@@ -1176,10 +1176,9 @@ skip_install=no && [[ -d $INSTALL_DIR ]]  && sout "INFO: Installation detected a
 
 if [[ ! -z "$EAP_LOCATION" ]]; then
   eap_location_created=no
-  # EAP_LOCATION="$WORKDIR/$EAP_LOCATION"
-  # readlink coomand does nothing here as the $EAP_LOCATION does not exists at this point!
-  # do you really need '-m' option here? It does not exists on Mac...
-  #EAP_LOCATION=$(readlink -mn "$EAP_LOCATION")
+  EAP_LOCATION="$WORKDIR/$EAP_LOCATION"
+  # '-m' option does not exists on Mac...
+  # EAP_LOCATION=$(readlink -mn "$EAP_LOCATION")
   mkdir -p "$EAP_LOCATION"&>/dev/null && eap_location_created=yes
   [[ "$eap_location_created" == "no" ]] && sout "ERROR: $EAP_LOCATION CANNOT BE CREATED - ABORTING" && exit 1
 fi


### PR DESCRIPTION
#### What is this PR About?
A regression was spotted after the last commit.
When no installation path is provided or the installation path is not an absolute on the resulting RHPAM installation is not starting.
This commit addresses that.

#### How do we test this?
Run with no installation path as an option and start RHPAM. it should start.

cc: @redhat-cop/businessautomation-cop
