### PR TITLE
updated pam-eap-setup github actions scripts to EAP.7.3.2 and PAM.7.8.0

### DIFF
--- a/.github/workflows/build-pam-eap-setup.yaml
+++ b/.github/workflows/build-pam-eap-setup.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           rh_username: ${{ secrets.RH_USERNAME }}
           rh_password: ${{ secrets.RH_PASSWORD }}
-          download: '[{"file":"/github/workspace/pam-eap-setup/jboss-eap-7.2.0.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=64311"},{"file":"/github/workspace/pam-eap-setup/jboss-eap-7.2.8-patch.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=81791"},{"file":"/github/workspace/pam-eap-setup/rhpam-7.7.1-business-central-eap7-deployable.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=82441"},{"file":"/github/workspace/pam-eap-setup/rhpam-7.7.1-kie-server-ee8.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=82291"}]'
+          download: '[{"file":"/github/workspace/pam-eap-setup/jboss-eap-7.3.0.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=80101"},{"file":"/github/workspace/pam-eap-setup/jboss-eap-7.3.2-patch.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=86401"},{"file":"/github/workspace/pam-eap-setup/rhpam-7.8.0-business-central-eap7-deployable.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=85631"},{"file":"/github/workspace/pam-eap-setup/rhpam-7.8.0-kie-server-ee8.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=85641"}]'
 
       - name: Run pam-setup.sh
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
#### What is this PR About?
As per $subject.
Gitub action scripts are now testing for RHPAM.7.8.0 on JBoss EAP.7.3.2

#### How do we test this?
Action scripts should finish successfully. 

cc: @redhat-cop/businessautomation-cop
