### PR TITLE
Added branch mapping to bcgithook

### DIFF
--- a/bcgithook/scripts/default.conf.example
+++ b/bcgithook/scripts/default.conf.example
@@ -95,7 +95,8 @@
 # BRANCH_ALLOW=br2,feature/fa
 # BRANCH_ALLOW_REGEX="^(hotfix/)|^(feature)"
 #
-# BRACH_MAP=""
+
+BRACH_MAP="damon:phintias,frodo:sam,earth:moon"
 
 LOG_LOCATION=$HOME
 LOG_SYSTEM_REPOS=yes

--- a/bcgithook/scripts/default.conf.example
+++ b/bcgithook/scripts/default.conf.example
@@ -96,7 +96,7 @@
 # BRANCH_ALLOW_REGEX="^(hotfix/)|^(feature)"
 #
 
-BRACH_MAP="damon:phintias,frodo:sam,earth:moon"
+BRANCH_MAP="damon:phintias,frodo:sam,earth:moon"
 
 LOG_LOCATION=$HOME
 LOG_SYSTEM_REPOS=yes

--- a/bcgithook/scripts/default.conf.example
+++ b/bcgithook/scripts/default.conf.example
@@ -18,6 +18,8 @@
 # LOG_SYSTEM_REPOS = [yes|no], set to "yes" to log access to PAM system
 #                              repositories, increases verbosity
 #
+# --- Selectively allow/deny pushing commits to remote repo
+#
 # BRANCH_DENY=master,release
 # BRANCH_ALLOW=br2,feature/fa
 # BRANCH_ALLOW_REGEX="^(hotfix/)|^(feature/)"
@@ -52,6 +54,16 @@
 # Commits in branch "devel" will not be pused to remote repo as BRANCH_ALLOW_REGEX overrides BRANCH_ALLOW
 # Only commits in branches starting with "hotfix/" or "feature/" will be pused to remote repo
 #
+#
+# --- Branch Mapping : Map one or more branches to different branches in remote repo
+# 
+# A comma-separated list of "SOURCE:TARGET" pairs that would map the source
+# branch SOURCE to branch TARGET on the remote repo.
+# Spaces between commas(,) or semi-colons(:) are trimmed.
+#
+# BRANCH_MAP="SOURCE1:TARGET1,SOURCE2:TARGET2,...."
+#
+#
 # Uncomment and modify as appropriate
 #
 # GIT_TYPE=""
@@ -83,6 +95,7 @@
 # BRANCH_ALLOW=br2,feature/fa
 # BRANCH_ALLOW_REGEX="^(hotfix/)|^(feature)"
 #
+# BRACH_MAP=""
 
 LOG_LOCATION=$HOME
 LOG_SYSTEM_REPOS=yes

--- a/bcgithook/scripts/post-commit.sh
+++ b/bcgithook/scripts/post-commit.sh
@@ -108,7 +108,7 @@ while read -rd,; do
 done <<<"$BRANCH_MAP,"
 
 declare -A bmapper
-for ndx in ${!list[@]}; do
+for ndx in "${!list[@]}"; do
   while read -rd:; do tmpar+=("$REPLY"); done <<<"${list[$ndx]}:"
   # k="${tmpar[0]}" && k="$(echo -e "${k}" | tr -d '[:space:]')"
   # get from array, tirm leading and trailing whitespace

--- a/bcgithook/scripts/post-commit.sh
+++ b/bcgithook/scripts/post-commit.sh
@@ -102,6 +102,22 @@ debug "START"
                           && debug "USER NAME, PASSWORD OR GIT URL IS MISSING - ABORTING" \
                           && exit 2
 
+# prepare any branch mappings
+while read -rd,; do
+  list+=("$REPLY");
+done <<<"$BRANCH_MAP,"
+
+declare -A bmapper
+for ndx in ${!list[@]}; do
+  while read -rd:; do tmpar+=("$REPLY"); done <<<"${list[$ndx]}:"
+  # k="${tmpar[0]}" && k="$(echo -e "${k}" | tr -d '[:space:]')"
+  # get from array, tirm leading and trailing whitespace
+  k="${tmpar[0]}" && k="${k#"${k%%[![:space:]]*}"}" && k="${k%"${k##*[![:space:]]}"}"
+  v="${tmpar[1]}" && v="${v#"${v%%[![:space:]]*}"}" && v="${v%"${v##*[![:space:]]}"}"
+  [[ -n "$k" ]] && [[ -n "$v" ]] && bmapper["$k"]="${v}"
+  unset tmpar
+done
+
 gitUserName="$GIT_USER_NAME"
 gitPasswd="$GIT_PASSWD"
 
@@ -170,14 +186,12 @@ for bru in $bruli; do
   if [[ "$deny" == "yes" ]]; then
     debug "COMMITS TO BRANCH [$bru] ARE NOT ALLOWED - COMMIT NOT PUSHED TO $remoteGitUrl"
   else
-    debug "PUSHING BRANCH [$bru] TO $remoteGitUrl"
-    git push -u "$BBID" "$bru":"$bru"
+    source="$bru"
+    target="$bru"
+    [ ${bmapper[$source]+xxx} ] && target="${bmapper[$source]}"
+    debug "PUSHING BRANCH [$source:$target] TO $remoteGitUrl"
+    git push -u "$BBID" "$source":"$target"
   fi
 done
 
 debug "END"
-
-#
-# INSTALLED AT : 2020-07-01 19:04:08
-#
-


### PR DESCRIPTION
#### What is this PR About?
Added functionality to bcgithook post commit git hooks for mapping local BC branches to branches in the remote git repo with different name.
For example mapping "master" to "mainline"

#### How do we test this?
Define BRANCH_MAP variable in config, for example BRANCH_MAP="master:mainline"

cc: @redhat-cop/businessautomation-cop
