### PR TITLE
added support for RHDM and RHPAM 7.9

### DIFF
--- a/.github/workflows/build-pam-eap-setup.yaml
+++ b/.github/workflows/build-pam-eap-setup.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           rh_username: ${{ secrets.RH_USERNAME }}
           rh_password: ${{ secrets.RH_PASSWORD }}
-          download: '[{"file":"/github/workspace/pam-eap-setup/jboss-eap-7.3.0.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=80101"},{"file":"/github/workspace/pam-eap-setup/jboss-eap-7.3.2-patch.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=86401"},{"file":"/github/workspace/pam-eap-setup/rhpam-7.8.0-business-central-eap7-deployable.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=85631"},{"file":"/github/workspace/pam-eap-setup/rhpam-7.8.0-kie-server-ee8.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=85641"}]'
+          download: '[{"file":"/github/workspace/pam-eap-setup/jboss-eap-7.3.0.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=80101"},{"file":"/github/workspace/pam-eap-setup/jboss-eap-7.3.3-patch.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=88471"},{"file":"/github/workspace/pam-eap-setup/rhpam-7.9.0-business-central-eap7-deployable.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=89691"},{"file":"/github/workspace/pam-eap-setup/rhpam-7.9.0-kie-server-ee8.zip","url":"https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=89701"}]'
 
       - name: Run pam-setup.sh
         if: matrix.os == 'ubuntu-latest'

--- a/pam-eap-setup/README.md
+++ b/pam-eap-setup/README.md
@@ -28,8 +28,9 @@ Supported (i.e. tested) versions:
   - patch level 7.2.x onwards supported for 7.5 and later
  - EAP 7.3
 	 - patch level 7.3.2 supported for PAM.7.8
-- PAM versions 7.2, 7.3, 7.3.1, 7.4, 7.5, 7.5.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1
-- DM version 7.3.1, 7.4.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1
+	 - patch level 7.3.3 supported for PAM.7.9
+- PAM versions 7.2, 7.3, 7.3.1, 7.4, 7.5, 7.5.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1, 7.9.0
+- DM version 7.3.1, 7.4.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1, 7.9.0
 
 For details about node configuration check out [Nodes Configuration](#nodes-configuration) section at the end of this document. Also:
 
@@ -142,6 +143,7 @@ Depending on PAM version the following files are required:
         | 7.7.1     | rhpam-7.7.1-business-central-eap7-deployable.zip, rhpam-7.7.1-kie-server-ee8.zip  |
         | 7.8       | rhpam-7.8.0-business-central-eap7-deployable.zip, rhpam-7.8.0-kie-server-ee8.zip  |
         | 7.8.1     | rhpam-7.8.1-business-central-eap7-deployable.zip, rhpam-7.8.1-kie-server-ee8.zip  |
+        | 7.9       | rhpam-7.9.0-business-central-eap7-deployable.zip, rhpam-7.9.0-kie-server-ee8.zip  |
 
         |DM Version| Files                                                                           |
         |----------|---------------------------------------------------------------------------------|
@@ -149,6 +151,8 @@ Depending on PAM version the following files are required:
         | 7.4.1    | rhdm-7.4.1-decision-central-eap7-deployable.zip, rhdm-7.4.1-kie-server-ee8.zip  |
         | 7.6.0    | rhdm-7.6.0-decision-central-eap7-deployable.zip, rhdm-7.6.0-kie-server-ee8.zip  |
         | 7.7.1    | rhdm-7.7.1-decision-central-eap7-deployable.zip, rhdm-7.7.1-kie-server-ee8.zip  |
+        | 7.8.1    | rhdm-7.8.1-decision-central-eap7-deployable.zip, rhdm-7.8.1-kie-server-ee8.zip  |
+        | 7.9      | rhdm-7.9.0-decision-central-eap7-deployable.zip, rhdm-7.9.0-kie-server-ee8.zip  |
 
 ## Usage
 

--- a/pam-eap-setup/pam-setup.sh
+++ b/pam-eap-setup/pam-setup.sh
@@ -143,6 +143,7 @@ MASTER_CONFIG=master.conf
 # versions supported
 #
 cat << "__CONFIG" > $MASTER_CONFIG
+DM790  | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhdm-7.9.0-decision-central-eap7-deployable.zip  | KIE_ZIP=rhdm-7.9.0-kie-server-ee8.zip  | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=DM
 DM781  | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhdm-7.8.1-decision-central-eap7-deployable.zip  | KIE_ZIP=rhdm-7.8.1-kie-server-ee8.zip  | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=DM
 PAM781 | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhpam-7.8.1-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.8.1-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=PAM
 PAM780 | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhpam-7.8.0-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.8.0-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=PAM

--- a/pam-eap-setup/pam-setup.sh
+++ b/pam-eap-setup/pam-setup.sh
@@ -143,6 +143,7 @@ MASTER_CONFIG=master.conf
 # versions supported
 #
 cat << "__CONFIG" > $MASTER_CONFIG
+PAM790 | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhpam-7.9.0-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.9.0-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=PAM
 DM790  | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhdm-7.9.0-decision-central-eap7-deployable.zip  | KIE_ZIP=rhdm-7.9.0-kie-server-ee8.zip  | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=DM
 DM781  | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhdm-7.8.1-decision-central-eap7-deployable.zip  | KIE_ZIP=rhdm-7.8.1-kie-server-ee8.zip  | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=DM
 PAM781 | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhpam-7.8.1-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.8.1-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=PAM


### PR DESCRIPTION
#### What is this PR About?
pam-eap-setup has been updated to handle RHDM and RHPAM 7.9.
Documentation has been updated as well.

#### How do we test this?
Installation with version 7.9 should result in a working system.

cc: @redhat-cop/businessautomation-cop
