### PR TITLE
Align bcgithook installation by pam-eap-setup to new git structure

### DIFF
--- a/deployment-examples/pam-eap-setup/README.md
+++ b/deployment-examples/pam-eap-setup/README.md
@@ -230,7 +230,7 @@ Invoke with `-h`, i.e. `./pam-setup  -h` for usage info:
                                
                  - git_hook          : install named post-commit git hook implementation
                                       Supported implementations are:
-                                       - 'bcgithook' : from https://github.com/redhat-cop/businessautomation-cop/tree/master/bcgithook
+                                       - 'bcgithook' : from https://github.com/redhat-cop/businessautomation-cop/tree/master/extras/bcgithook
                                        - 'kiegroup'  : from https://github.com/kiegroup/bc-git-integration-push
                                        
                  - git_hook_location : location of post-commit git hooks implementation

--- a/deployment-examples/pam-eap-setup/pam-setup.sh
+++ b/deployment-examples/pam-eap-setup/pam-setup.sh
@@ -211,17 +211,6 @@ function sout() {
   done
 }
 
-function waitForKey() {
-  echo '... :::         ::: ...'
-  echo '... ::: WAITING ::: ...'
-  echo '... :::         ::: ...'
-  echo
-  echo "$@"
-  echo
-  read -r -p 'Press ENTER key to continue...'
-  echo
-}
-
 function checkEnv() {
   local sw="$1"
   [[ "$sw" == "curl" ]] && ( command -v curl &> /dev/null || { echo >&2 'ERROR: curl not installed. Please install curl to continue - Aborting'; exit 1; } )
@@ -383,11 +372,11 @@ Options:
                                
          - git_hook          : install named post-commit git hook implementation
                               Supported implementations are:
-                               - 'bcgithook' : from https://github.com/redhat-cop/businessautomation-cop/tree/master/bcgithook
+                               - 'bcgithook' : from https://github.com/redhat-cop/businessautomation-cop/tree/master/extras/bcgithook
                                - 'kiegroup'  : from https://github.com/kiegroup/bc-git-integration-push
                                
          - git_hook_location : location of post-commit git hooks implementation
-                               Valid values are [ (empty) | download | path-to-githook]
+                               Valid values are [ (empty) | download | path-to-githook ]
                                Please refer to the documentation for valid values
                                'git_hook_location' is only taken into account if 'git_hook' has a valid value
                                
@@ -1007,7 +996,7 @@ function installBCGitHook() {
       mkdir bcgithook && cd bcgithook
       curl -ks -L -O https://github.com/redhat-cop/businessautomation-cop/archive/master.zip
       unzip -qq master.zip
-      [[ -d businessautomation-cop-master/bcgithook ]] && cd businessautomation-cop-master/bcgithook && ghl="$(pwd)"
+      [[ -d businessautomation-cop-master/extras/bcgithook ]] && cd businessautomation-cop-master/extras/bcgithook && ghl="$(pwd)"
     fi
     if [[ -n "${configOptions[git_hook_location]}" ]] && [[ "${configOptions[git_hook_location]}" != "download" ]]; then
       local tmp="${configOptions[git_hook_location]}"


### PR DESCRIPTION
#### What is this PR About?
pam-eap-setup allows for automatic installation of bcgithook from ba-cop repository.
This needs aligning with the new structure of the repository

#### How do we test this?
git hooks should be installed by pam-eap-setup

cc: @redhat-cop/businessautomation-cop
