### PR TITLE
Expand pam-eap-setup configuration options, per installation bcgithook configuration and documentation updates

### DIFF
--- a/deployment-examples/pam-eap-setup/README.md
+++ b/deployment-examples/pam-eap-setup/README.md
@@ -29,6 +29,7 @@ Supported (i.e. tested) versions:
  - EAP 7.3
 	 - patch level 7.3.2 supported for PAM.7.8
 	 - patch level 7.3.3, 7.3.4 supported for PAM.7.9 and PAM.7.9.1
+   - patch JBEAP-20659 for EAP.7.3.4 to restore password vault functionality
 - PAM versions 7.2, 7.3, 7.3.1, 7.4, 7.5, 7.5.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1, 7.9.0
 - DM version 7.3.1, 7.4.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1, 7.9.0, 7.9.1
 

--- a/deployment-examples/pam-eap-setup/README.md
+++ b/deployment-examples/pam-eap-setup/README.md
@@ -30,7 +30,7 @@ Supported (i.e. tested) versions:
 	 - patch level 7.3.2 supported for PAM.7.8
 	 - patch level 7.3.3, 7.3.4 supported for PAM.7.9 and PAM.7.9.1
    - patch JBEAP-20659 for EAP.7.3.4 to restore password vault functionality
-- PAM versions 7.2, 7.3, 7.3.1, 7.4, 7.5, 7.5.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1, 7.9.0
+- PAM versions 7.2, 7.3, 7.3.1, 7.4, 7.5, 7.5.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1, 7.9.0, 7.9.1
 - DM version 7.3.1, 7.4.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1, 7.9.0, 7.9.1
 
 For details about node configuration check out [Nodes Configuration](#nodes-configuration) section at the end of this document. Also:
@@ -145,6 +145,7 @@ Depending on PAM version the following files are required:
         | 7.8       | rhpam-7.8.0-business-central-eap7-deployable.zip, rhpam-7.8.0-kie-server-ee8.zip  |
         | 7.8.1     | rhpam-7.8.1-business-central-eap7-deployable.zip, rhpam-7.8.1-kie-server-ee8.zip  |
         | 7.9       | rhpam-7.9.0-business-central-eap7-deployable.zip, rhpam-7.9.0-kie-server-ee8.zip  |
+        | 7.9.1     | rhpam-7.9.1-business-central-eap7-deployable.zip, rhpam-7.9.1-kie-server-ee8.zip  |
 
         |DM Version| Files                                                                           |
         |----------|---------------------------------------------------------------------------------|

--- a/deployment-examples/pam-eap-setup/README.md
+++ b/deployment-examples/pam-eap-setup/README.md
@@ -598,6 +598,17 @@ Same for subsequent nodes by specifying `node2` for node 2, `node3` for node 3 a
 
 The file `addons/access_log` will enable basic loggin to access_log for EAP. To use this file specify it in the `-o` options like `-o node1_config=addons/access_log`. This file implements the [How to enable access logging for JBoss EAP 7?](https://access.redhat.com/solutions/2423311) KB article.
 
+Additional documentation that could be useful for subsequent tuning:
+
+  - [Access log pattern %D and %T (response time) prints "-" in Undertow in JBoss EAP 7](https://access.redhat.com/solutions/2172691)
+  - [How to filter specific messages from access logging in EAP 7](https://access.redhat.com/solutions/4492811) 
+  - [How to customize date format pattern for access logging in JBoss EAP 7](https://access.redhat.com/solutions/2821021)
+  - [How to customize access log rotation in EAP 7](https://access.redhat.com/solutions/2773641)
+  - [Access log trims URL in JBoss EAP 7](https://access.redhat.com/solutions/5430031)
+  - [Does the JBoss access log support millisecond timestamps?](https://access.redhat.com/solutions/2949811)
+  - JBoss EAP.7.2 documentation: access-log attributes : https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/configuration_guide/index#access_log_attributes
+
+
 ---
 > Written with [StackEdit](https://stackedit.io/).
 > ASCII charts with the help of [ASCIIFlow](http://asciiflow.com/)

--- a/deployment-examples/pam-eap-setup/README.md
+++ b/deployment-examples/pam-eap-setup/README.md
@@ -28,9 +28,9 @@ Supported (i.e. tested) versions:
   - patch level 7.2.x onwards supported for 7.5 and later
  - EAP 7.3
 	 - patch level 7.3.2 supported for PAM.7.8
-	 - patch level 7.3.3 supported for PAM.7.9
+	 - patch level 7.3.3, 7.3.4 supported for PAM.7.9 and PAM.7.9.1
 - PAM versions 7.2, 7.3, 7.3.1, 7.4, 7.5, 7.5.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1, 7.9.0
-- DM version 7.3.1, 7.4.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1, 7.9.0
+- DM version 7.3.1, 7.4.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1, 7.9.0, 7.9.1
 
 For details about node configuration check out [Nodes Configuration](#nodes-configuration) section at the end of this document. Also:
 
@@ -153,6 +153,7 @@ Depending on PAM version the following files are required:
         | 7.7.1    | rhdm-7.7.1-decision-central-eap7-deployable.zip, rhdm-7.7.1-kie-server-ee8.zip  |
         | 7.8.1    | rhdm-7.8.1-decision-central-eap7-deployable.zip, rhdm-7.8.1-kie-server-ee8.zip  |
         | 7.9      | rhdm-7.9.0-decision-central-eap7-deployable.zip, rhdm-7.9.0-kie-server-ee8.zip  |
+        | 7.9.1    | rhdm-7.9.1-decision-central-eap7-deployable.zip, rhdm-7.9.1-kie-server-ee8.zip  |
 
 ## Usage
 

--- a/deployment-examples/pam-eap-setup/README.md
+++ b/deployment-examples/pam-eap-setup/README.md
@@ -44,7 +44,7 @@ For details about node configuration check out [Nodes Configuration](#nodes-conf
 	- [for bcgithook](#for-bcgithook)
 	- [for kiegroup](#for-kiegroup)
 - [Configuring EAP](#configuring-eap)
- - [Enabling access_log](#enabling-access_log)
+  - [Enabling access_log](#enabling-access_log)
 
 ## Usage Scenarios
 

--- a/deployment-examples/pam-eap-setup/README.md
+++ b/deployment-examples/pam-eap-setup/README.md
@@ -44,6 +44,7 @@ For details about node configuration check out [Nodes Configuration](#nodes-conf
 	- [for bcgithook](#for-bcgithook)
 	- [for kiegroup](#for-kiegroup)
 - [Configuring EAP](#configuring-eap)
+ - [Enabling access_log](#enabling-access_log)
 
 ## Usage Scenarios
 
@@ -593,6 +594,9 @@ If both a file in the `addons` directory corresponding to a node is found and an
 
 Same for subsequent nodes by specifying `node2` for node 2, `node3` for node 3 and so on.
 
+#### Enabling access_log
+
+The file `addons/access_log` will enable basic loggin to access_log for EAP. To use this file specify it in the `-o` options like `-o node1_config=addons/access_log`. This file implements the [How to enable access logging for JBoss EAP 7?](https://access.redhat.com/solutions/2423311) KB article.
 
 ---
 > Written with [StackEdit](https://stackedit.io/).

--- a/deployment-examples/pam-eap-setup/README.md
+++ b/deployment-examples/pam-eap-setup/README.md
@@ -464,7 +464,22 @@ brokerconfig.maxDiskUsage               95
 
 # Oracle: check https://access.redhat.com/solutions/4460791
 # org.kie.server.persistence.dialect   org.jbpm.persistence.jpa.hibernate.DisabledFollowOnLockOracle10gDialect
+
+# process variable values longer than 255 chars in VariableInstanceLog
+# https://access.redhat.com/solutions/917923 plus database schema changes
+# org.jbpm.var.log.length             1000
+#
+# for Human Tasks
+# org.jbpm.task.var.log.length        4000
+
+#
+# enable Prometheus endpoints
+# access metrics at: http://localhost:8080/kie-server/services/rest/metrics
+# 
+org.kie.prometheus.server.ext.disabled  false
 ```
+
+- The default entries for `pam.config` will enable Prometheus endpoints. Prometheus endpoints are available from version 7.4.0 onwards and can be accessed through `http://{{ kie-server  }}/services/rest/metrics` URL. More information can also be found at https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.9/html-single/managing_red_hat_decision_manager_and_kie_server_settings/index#prometheus-monitoring-con_execution-server
 
 Add as many configuration parameters as required separating the parameters from its value by at least a space.
 

--- a/deployment-examples/pam-eap-setup/addons/access_log
+++ b/deployment-examples/pam-eap-setup/addons/access_log
@@ -1,0 +1,3 @@
+/subsystem=undertow/server=default-server/http-listener=default:write-attribute(name=record-request-start-time,value=true)
+/subsystem=undertow/server=default-server/host=default-host/setting=access-log:add(pattern="%h %l %u %t \"%r\" %s %b \"%{i,Referer}\" \"%{i,User-Agent}\" Cookie: \"%{i,COOKIE}\" Set-Cookie: \"%{o,SET-COOKIE}\" SessionID: %S Thread: \"%I\" TimeTaken: %T")
+

--- a/deployment-examples/pam-eap-setup/pam-setup.sh
+++ b/deployment-examples/pam-eap-setup/pam-setup.sh
@@ -143,6 +143,7 @@ MASTER_CONFIG=master.conf
 # versions supported
 #
 cat << "__CONFIG" > $MASTER_CONFIG
+PAM791 | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhpam-7.9.1-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.9.1-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=PAM
 DM791  | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhdm-7.9.1-decision-central-eap7-deployable.zip  | KIE_ZIP=rhdm-7.9.1-kie-server-ee8.zip  | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=DM
 PAM790 | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhpam-7.9.0-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.9.0-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=PAM
 DM790  | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhdm-7.9.0-decision-central-eap7-deployable.zip  | KIE_ZIP=rhdm-7.9.0-kie-server-ee8.zip  | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=DM

--- a/deployment-examples/pam-eap-setup/pam.config
+++ b/deployment-examples/pam-eap-setup/pam.config
@@ -22,4 +22,9 @@ brokerconfig.maxDiskUsage               95
 # for Human Tasks
 # org.jbpm.task.var.log.length        4000
 
+#
+# enable Prometheus endpoints
+# access metrics at: http://localhost:8080/kie-server/services/rest/metrics
+# 
+org.kie.prometheus.server.ext.disabled  false
 

--- a/extras/bcgithook/README.md
+++ b/extras/bcgithook/README.md
@@ -14,7 +14,11 @@ This project offers a bash-based implementation for such git hooks.
 * Configurable logging of operations
 * [Branch mapping](#branch-mapping), map branches from BC to remote Git repos
 ## Configuration
-**bcgithook** will look for its configuration in file `default.conf` placed in `$HOME/.bcgithook` directory. This file must be present event if per-project configuration files are used. The following variables need to be configured:
+**bcgithook** will look for its configuration in file `default.conf` placed in `$HOME/.bcgithook` directory. This file must be present event if per-project configuration files are used. 
+
+The provided installation script will install the `default.conf` file in the `$JBOSS_HOME/git-hooks` directory as well. Configuration files in the `$JBOSS_HOME/git-hooks` directory take precedence over the files in the `$HOME/.bcgithook` directory.
+
+The following variables need to be configured:
 
 |Variable|Type|Content|
 |--|--|--|
@@ -82,6 +86,8 @@ Please note that there is currently no way of acheiving the reverse. For example
 **bcgithook** allows for different configuration per-project. For this to happen a file with the same name as the project having the `.conf` suffix should be placed in `$HOME/.bcgithook` directory. `default.conf` can be used as a template however only values that are different from `default.conf` need to be defined. For example, a project named "FormApplicationProcess" would use the `FormApplicationProcess.conf` configuration file if that file is found.
 
 > Please follow case sensitivity rules for your operating system when naming configuration files.
+
+Per project configuration files can also be placed at the `$JBOSS_HOME/git-hooks` directory. Configuration files placed in this directory take precedence over files in the `$HOME/.bcgithook` directory.
 
 For new projects you can create the configuration beforehand so when BusinessCentral creates them the project specific configuration will be used automatically. That way different projects created in BusinessCentral can be associated to different repositories.
 

--- a/extras/bcgithook/install.sh
+++ b/extras/bcgithook/install.sh
@@ -177,6 +177,14 @@ mkdir -p "$gitHookDir"
 [[ ! -d "$gitHookDir" ]] && error "- GIT HOOKS DIRECTORY CANNOT BE CREATED - ABORTING" && exit 6
 
 cp "$POST_COMMIT_SOURCE" "$gitHookDir/post-commit" || ( error "- POST COMMIT SCRIPT CANNOT BE COPIED INTO PLACE - ABORTING" && exit 7 )
+if [[ ! -r "$gitHookDir"/default.conf ]]; then
+  cp "$DEFAULT_CONF_SOURCE" "$gitHookDir"/default.conf || ( error "- CONFIGURATION FILE CANNOT BE COPIED INTO PLACE - ABORTING" && exit 5 )
+else
+  cp "$DEFAULT_CONF_SOURCE" "$gitHookDir"/default.conf.new || ( error "- CONFIGURATION FILE CANNOT BE COPIED INTO PLACE - ABORTING" && exit 5 )
+  sout "${bold}${white}CONFIGURATION FILE NOT INSTALLED${normal} - EXISTING CONFIGURATION FILE NOT OVERRIDEN"
+  sout "${bold}${white}NEW CONFIGURATION FILE COPIED AS .new${normal}"
+fi
+
 echo "
 #                                             
 # INSTALLED AT : $(date '+%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
#### What is this PR About?
(1) pam-eap-setup can handle RHPAM.7.9.1, enables Prometheus endpoints by default and provides for access_log logging
(2) bcgithooks facilitates multiple installation by allowing configuration per installation on top of the global one
(3) Documentation updates for the new functionality

#### How do we test this?
Use pam-eap-setup to install enabling bcgithooks and take advantage of per installation configuration

cc: @redhat-cop/businessautomation-cop
