### PR TITLE
bugfix: pam-vagrant can now handle DecisionManager

### DIFF
--- a/extras/pam-vagrant/README.md
+++ b/extras/pam-vagrant/README.md
@@ -55,4 +55,18 @@ At the end of the setup while the vagrant box is being fired up for the first ti
 
 - 4096MB of memory will be allocated to the VagrantBox. If you wish to increase this please modify accordingly [line 7](https://github.com/erouvas/businessautomation-cop/blob/e3e9e8dab24527df0711d49bd3baa310cdc00896/extras/pam-vagrant/Vagrantfile#L7) of the [Vagrantfile](https://github.com/erouvas/businessautomation-cop/blob/master/extras/pam-vagrant/Vagrantfile)
 
+- If you wish to use different ports than `8080` and `8081` to access RHPAM and Nexus respectively, modify accordingly the `host` value in [Vagrantfile](https://github.com/erouvas/businessautomation-cop/blob/master/extras/pam-vagrant/Vagrantfile) for lines [37](https://github.com/erouvas/businessautomation-cop/blob/85523f7b7b751df93d8340cfda94ba32d78aada7/extras/pam-vagrant/Vagrantfile#L37) and [38](https://github.com/erouvas/businessautomation-cop/blob/85523f7b7b751df93d8340cfda94ba32d78aada7/extras/pam-vagrant/Vagrantfile#L38)
+
+- To create the VagrantBox, use `vagrant up`. The same command can be used to start a box after it has been stopped.
+
+- To stop the VagrantBox, use `vagrant halt`
+
+- To destroy the VagrantBox, use `vagrant destroy`. If you destroy the box all data and projects will be deleted so make sure you have back them up to a safe location if you want to keep them. 
+
+- The VagrantBox can be recreated any time by using the `vagrant up` command.
+
+- You can ssh into the VagrantBox by using `vagrant ssh`. Once inside you can use `sudo su -` and navigate to the `/opt/jboss/` directory to check RHPAM installation details
+
+- For more details about Vagrant, please refer to the official documentation at https://www.vagrantup.com/docs
+
 

--- a/extras/pam-vagrant/README.md
+++ b/extras/pam-vagrant/README.md
@@ -47,3 +47,12 @@ For EAP.7.2 the file `jboss-eap-7.2.0.zip` is required as well as the latest pat
 JBoss EAP.7.3, file `jboss-eap-7.3.0.zip`, along with the latest patch, is required for RHPAM.7.8.1 onwards 
 
 At the end of the setup while the vagrant box is being fired up for the first time please wait until PAM is fully loaded to validate the installation. Depending on the local environment it could take up to a minute for PAM to be operational.
+
+
+## Installation notes
+
+- The Vagrant box launched will be named `PAM7.CentOS8` and relies on VirtualBox to be installed
+
+- 4096MB of memory will be allocated to the VagrantBox. If you wish to increase this please modify accordingly [line 7](https://github.com/erouvas/businessautomation-cop/blob/e3e9e8dab24527df0711d49bd3baa310cdc00896/extras/pam-vagrant/Vagrantfile#L7) of the [Vagrantfile](https://github.com/erouvas/businessautomation-cop/blob/master/extras/pam-vagrant/Vagrantfile)
+
+

--- a/extras/pam-vagrant/bootstrap.sh
+++ b/extras/pam-vagrant/bootstrap.sh
@@ -76,7 +76,7 @@ counter=0
 goon=no
 while [[ "$goon" == "no" ]]; do
   let counter=$((counter+1))
-  if [[ ! -r /opt/jboss/standalone/deployments/business-central.war.deployed ]]; then
+  if [[ ! -r /opt/jboss/standalone/deployments/business-central.war.deployed ]] && [[ ! -r /opt/jboss/standalone/deployments/decision-central.war.deployed ]] ; then
     echo "[ $counter ] Waiting for PAM to be fully deployed... will check again in 5 seconds..."
     sleep 5s
   else


### PR DESCRIPTION
#### What is this PR About?
Fix the installation procedure used by pam-vagrant to handle RHDM as well as RHPAM

#### How do we test this?
Use DecisionManager binaries to set up a vagrant box

cc: @redhat-cop/businessautomation-cop
