### PR TITLE
make user configurable for systemd installation of PAM

### DIFF
--- a/extras/pam-vagrant/bootstrap.sh
+++ b/extras/pam-vagrant/bootstrap.sh
@@ -67,16 +67,18 @@ popd &> /dev/null
 #
 # systemd integration
 #
-$BASE_DIR/pam7-systemd-integration.sh
+TARGET_USER=pamservice
+$BASE_DIR/pam7-systemd-integration.sh $TARGET_USER
 
 #
 # Continue with RHPAM and BC setup
 #
 counter=0
 goon=no
+check_deploy_dir="/opt/$TARGET_USER/standalone/deployments"
 while [[ "$goon" == "no" ]]; do
   let counter=$((counter+1))
-  if [[ ! -r /opt/jboss/standalone/deployments/business-central.war.deployed ]] && [[ ! -r /opt/jboss/standalone/deployments/decision-central.war.deployed ]] ; then
+  if [[ ! -r "$check_deploy_dir"/business-central.war.deployed ]] && [[ ! -r "$check_deploy_dir"/decision-central.war.deployed ]] ; then
     echo "[ $counter ] Waiting for PAM to be fully deployed... will check again in 5 seconds..."
     sleep 5s
   else

--- a/extras/pam-vagrant/pam7-systemd-integration.sh
+++ b/extras/pam-vagrant/pam7-systemd-integration.sh
@@ -2,21 +2,23 @@
 
 INSTALL_DIR=/opt
 
+TARGET_USER=${1:-pamuser}
+
 #
 # - Install PAM.7 as a systemd service
 #
-groupadd -r jboss
-useradd -r -g jboss -d ${INSTALL_DIR}/jboss -s /sbin/nologin jboss
+groupadd -r $TARGET_USER
+useradd -r -g $TARGET_USER -d ${INSTALL_DIR}/$TARGET_USER -s /sbin/nologin $TARGET_USER
 src_dir=jboss-eap-7.2 && [[ -d pam ]] && src_dir=pam
 mv "$src_dir" "${INSTALL_DIR}"
-echo 'JAVA_OPTS="$JAVA_OPTS -Xmx2048m "' >> ${INSTALL_DIR}/"${src_dir}"/bin/standalone.conf
-ln -s ${INSTALL_DIR}/"${src_dir}" ${INSTALL_DIR}/jboss
+# echo 'JAVA_OPTS="$JAVA_OPTS -Xmx2048m "' >> ${INSTALL_DIR}/"${src_dir}"/bin/standalone.conf
+ln -s ${INSTALL_DIR}/"${src_dir}" ${INSTALL_DIR}/$TARGET_USER
 cp ${INSTALL_DIR}/"${src_dir}"/settings.xml /etc/maven/settings.xml
-chown -R jboss:jboss ${INSTALL_DIR}/jboss
-chown -R jboss:jboss ${INSTALL_DIR}/"${src_dir}"
-mkdir /etc/jboss
+chown -R $TARGET_USER:$TARGET_USER ${INSTALL_DIR}/$TARGET_USER
+chown -R $TARGET_USER:$TARGET_USER ${INSTALL_DIR}/"${src_dir}"
+mkdir /etc/$TARGET_USER
 
-cat << __JBOSS > /etc/jboss/jboss.conf
+cat << __JBOSS > /etc/$TARGET_USER/$TARGET_USER.conf
 # The configuration you want to run
 JBOSS_CONFIG=standalone.xml
 
@@ -27,11 +29,11 @@ JBOSS_MODE=standalone
 JBOSS_BIND=0.0.0.0
 __JBOSS
 
-cat << __JBOSS_LAUNCH > ${INSTALL_DIR}/jboss/bin/launch.sh
+cat << __JBOSS_LAUNCH > ${INSTALL_DIR}/$TARGET_USER/bin/launch.sh
 #!/bin/bash
 
 if [ "x\$JBOSS_HOME" = "x" ]; then
-    JBOSS_HOME="${INSTALL_DIR}/jboss"
+    JBOSS_HOME="${INSTALL_DIR}/$TARGET_USER"
 fi
 
 if [[ "\$1" == "domain" ]]; then
@@ -40,10 +42,10 @@ else
     \$JBOSS_HOME/bin/standalone.sh -c \$2 -b \$3
 fi
 __JBOSS_LAUNCH
-chown jboss:jboss ${INSTALL_DIR}/jboss/bin/launch.sh
-chmod +x ${INSTALL_DIR}/jboss/bin/launch.sh
+chown $TARGET_USER:$TARGET_USER ${INSTALL_DIR}/$TARGET_USER/bin/launch.sh
+chmod +x ${INSTALL_DIR}/$TARGET_USER/bin/launch.sh
 
-cat << __JBOSS_SERVICE > /etc/systemd/system/jboss.service
+cat << __JBOSS_SERVICE > /etc/systemd/system/$TARGET_USER.service
 [Unit]
 Description=The JBoss EAP Server
 After=syslog.target network.target
@@ -51,11 +53,11 @@ Before=httpd.service
 
 [Service]
 Environment=LAUNCH_JBOSS_IN_BACKGROUND=1
-EnvironmentFile=-/etc/jboss/jboss.conf
-User=jboss
+EnvironmentFile=-/etc/$TARGET_USER/$TARGET_USER.conf
+User=$TARGET_USER
 LimitNOFILE=102642
-PIDFile=/var/run/jboss/jboss.pid
-ExecStart=${INSTALL_DIR}/jboss/bin/launch.sh \$JBOSS_MODE \$JBOSS_CONFIG \$JBOSS_BIND
+PIDFile=/var/run/$TARGET_USER/$TARGET_USER.pid
+ExecStart=${INSTALL_DIR}/$TARGET_USER/bin/launch.sh \$JBOSS_MODE \$JBOSS_CONFIG \$JBOSS_BIND
 StandardOutput=null
 
 [Install]
@@ -63,11 +65,11 @@ WantedBy=multi-user.target
 __JBOSS_SERVICE
 
 # - setup log folder
-mkdir /var/log/jboss && \
-chown jboss:jboss /var/log/jboss
+mkdir /var/log/$TARGET_USER && \
+chown $TARGET_USER:$TARGET_USER /var/log/$TARGET_USER
 
 # - setup jboss as a service
 systemctl daemon-reload
-systemctl enable jboss.service
-systemctl start jboss.service
+systemctl enable $TARGET_USER.service
+systemctl start $TARGET_USER.service
 


### PR DESCRIPTION
#### What is this PR About?
Installation of PAM as a systemd service accepts a user parameter for PAM to be installed into

#### How do we test this?
PAM is no longer installed as the "jboss" user; the user is configurable 

cc: @redhat-cop/businessautomation-cop
