### PR TITLE
Fixing readme console URLs and camel swagger api docs

### DIFF
--- a/coded-examples/spring-boot-examples/drools/drools-sboot-embedded/.gitignore
+++ b/coded-examples/spring-boot-examples/drools/drools-sboot-embedded/.gitignore
@@ -1,1 +1,2 @@
 /target/
+.vscode/

--- a/coded-examples/spring-boot-examples/drools/drools-sboot-embedded/README.md
+++ b/coded-examples/spring-boot-examples/drools/drools-sboot-embedded/README.md
@@ -32,8 +32,8 @@ RESPONSE { "rulesFired": 1, "message": " Goodbye Paulo " }
 
 #### Useful Links: 
 
-- Context Root: \<HOST>:8090/rest
-- KIE Server Base : http://localhost:8090/rest/server
-- KIE Server Containers : http://localhost:8090/rest/server/containers
-- Swagger JSON: http://localhost:8090/rest/swagger.json
-- Swagger UI: http://localhost:8090/rest/api-docs?url=http://localhost:8090/rest/swagger.json
+- Context Root: \<HOST>:8090/api
+- Swagger JSON: http://localhost:8090/api/api-doc
+- Swagger UI: http://localhost:8090/webjars/swagger-ui/index.html?url=/api/api-doc
+- Spring Management (Actuator): http://localhost:8091/actuator/
+- H2 Console: http://localhost:8090/h2-console

--- a/coded-examples/spring-boot-examples/drools/drools-sboot-embedded/pom.xml
+++ b/coded-examples/spring-boot-examples/drools/drools-sboot-embedded/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <version.spring.boot.bom>2.1.3.Final-redhat-00001</version.spring.boot.bom>
         <version.camel.bom>2.23.2.fuse-740011-redhat-00001</version.camel.bom>
-        <version.swagger>3.22.2</version.swagger>
+        <version.swagger>3.44.0</version.swagger>
         <version.webjars.locator>0.36</version.webjars.locator>
         <version.mapstruct>1.3.0.Final</version.mapstruct>
 
@@ -128,7 +128,7 @@
             <artifactId>mapstruct-jdk8</artifactId>
         </dependency>
 
-        <!-- Swagger UI -->
+        <!-- Swagger UI -->        
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>swagger-ui</artifactId>

--- a/coded-examples/spring-boot-examples/drools/drools-sboot-embedded/src/main/java/org/redhat/services/util/RoutingConstants.java
+++ b/coded-examples/spring-boot-examples/drools/drools-sboot-embedded/src/main/java/org/redhat/services/util/RoutingConstants.java
@@ -5,8 +5,8 @@ public class RoutingConstants {
     // API Routing API
     public static String API_BASE = "/api/";
     public static String SWAGGER_ENDPOINT = "api-doc";
-    public static String DEMO_ENDPOINT = "demo/rules/";
-    public static String AUDIT_ENDPOINT = "audit/rules/";
+    public static String DEMO_ENDPOINT = "/demo/rules/";
+    public static String AUDIT_ENDPOINT = "/audit/rules/";
 
     // Camel Endpoint Types
     public static final String DIRECT = "direct:";

--- a/coded-examples/spring-boot-examples/drools/drools-sboot-embedded/src/main/resources/application.yml
+++ b/coded-examples/spring-boot-examples/drools/drools-sboot-embedded/src/main/resources/application.yml
@@ -41,6 +41,8 @@ camel:
     #        version: v1
 
 management:
+  server:
+    port: 8091
   endpoint:
     health:
       show-details: always


### PR DESCRIPTION
#### What is this PR About?
Fixing readme with the correct Consoles URLs
Fixing Camel swagger api-docs to test via Swagger UI

#### How do we test this?
```
 mvn clean compile spring-boot:run -Ph2 
```

and access the following URLs:
- Swagger JSON: http://localhost:8090/api/api-doc
- Swagger UI: http://localhost:8090/webjars/swagger-ui/index.html?url=/api/api-doc
- Spring Management (Actuator): http://localhost:8091/actuator/
- H2 Console: http://localhost:8090/h2-console

cc: @redhat-cop/businessautomation-cop
