### PR TITLE
pam-eap-setup updates for rhdm.7.10.1

### DIFF
--- a/deployment-examples/pam-eap-setup/README.md
+++ b/deployment-examples/pam-eap-setup/README.md
@@ -30,8 +30,9 @@ Supported (i.e. tested) versions:
 	 - patch level 7.3.2 supported for PAM.7.8
 	 - patch level 7.3.3, 7.3.4 supported for PAM.7.9 and PAM.7.9.1
    - patch JBEAP-20659 for EAP.7.3.4 to restore password vault functionality
+  - patch level 7.3.5+ for RHPAM/RHDM 7.10 onwards
 - PAM versions 7.2, 7.3, 7.3.1, 7.4, 7.5, 7.5.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1, 7.9.0, 7.9.1
-- DM version 7.3.1, 7.4.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1, 7.9.0, 7.9.1
+- DM version 7.3.1, 7.4.1, 7.6.0, 7.7.0, 7.7.1, 7.8.0, 7.8.1, 7.9.0, 7.9.1, 7.10.0, 7.10.1
 
 For details about node configuration check out [Nodes Configuration](#nodes-configuration) section at the end of this document. Also:
 
@@ -148,15 +149,17 @@ Depending on PAM version the following files are required:
         | 7.9       | rhpam-7.9.0-business-central-eap7-deployable.zip, rhpam-7.9.0-kie-server-ee8.zip  |
         | 7.9.1     | rhpam-7.9.1-business-central-eap7-deployable.zip, rhpam-7.9.1-kie-server-ee8.zip  |
 
-        |DM Version| Files                                                                           |
-        |----------|---------------------------------------------------------------------------------|
-        | 7.3.1    | rhdm-7.3.1-decision-central-eap7-deployable.zip, rhdm-7.3.1-kie-server-ee8.zip  |
-        | 7.4.1    | rhdm-7.4.1-decision-central-eap7-deployable.zip, rhdm-7.4.1-kie-server-ee8.zip  |
-        | 7.6.0    | rhdm-7.6.0-decision-central-eap7-deployable.zip, rhdm-7.6.0-kie-server-ee8.zip  |
-        | 7.7.1    | rhdm-7.7.1-decision-central-eap7-deployable.zip, rhdm-7.7.1-kie-server-ee8.zip  |
-        | 7.8.1    | rhdm-7.8.1-decision-central-eap7-deployable.zip, rhdm-7.8.1-kie-server-ee8.zip  |
-        | 7.9      | rhdm-7.9.0-decision-central-eap7-deployable.zip, rhdm-7.9.0-kie-server-ee8.zip  |
-        | 7.9.1    | rhdm-7.9.1-decision-central-eap7-deployable.zip, rhdm-7.9.1-kie-server-ee8.zip  |
+        |DM Version| Files                                                                             |
+        |----------|-----------------------------------------------------------------------------------|
+        | 7.3.1    | rhdm-7.3.1-decision-central-eap7-deployable.zip, rhdm-7.3.1-kie-server-ee8.zip    |
+        | 7.4.1    | rhdm-7.4.1-decision-central-eap7-deployable.zip, rhdm-7.4.1-kie-server-ee8.zip    |
+        | 7.6.0    | rhdm-7.6.0-decision-central-eap7-deployable.zip, rhdm-7.6.0-kie-server-ee8.zip    |
+        | 7.7.1    | rhdm-7.7.1-decision-central-eap7-deployable.zip, rhdm-7.7.1-kie-server-ee8.zip    |
+        | 7.8.1    | rhdm-7.8.1-decision-central-eap7-deployable.zip, rhdm-7.8.1-kie-server-ee8.zip    |
+        | 7.9      | rhdm-7.9.0-decision-central-eap7-deployable.zip, rhdm-7.9.0-kie-server-ee8.zip    |
+        | 7.9.1    | rhdm-7.9.1-decision-central-eap7-deployable.zip, rhdm-7.9.1-kie-server-ee8.zip    |
+        | 7.10.0   | rhdm-7.10.0-decision-central-eap7-deployable.zip, rhdm-7.10.0-kie-server-ee8.zip  |
+        | 7.10.1   | rhdm-7.10.1-decision-central-eap7-deployable.zip, rhdm-7.10.1-kie-server-ee8.zip  |
 
 ## Usage
 

--- a/deployment-examples/pam-eap-setup/pam-setup.sh
+++ b/deployment-examples/pam-eap-setup/pam-setup.sh
@@ -143,6 +143,7 @@ MASTER_CONFIG=master.conf
 # versions supported
 #
 cat << "__CONFIG" > $MASTER_CONFIG
+DM7101  | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhdm-7.10.1-decision-central-eap7-deployable.zip  | KIE_ZIP=rhdm-7.10.1-kie-server-ee8.zip  | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=DM
 PAM7100 | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhpam-7.10.0-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.10.0-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=PAM
 DM7100  | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhdm-7.10.0-decision-central-eap7-deployable.zip  | KIE_ZIP=rhdm-7.10.0-kie-server-ee8.zip  | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=DM
 PAM791  | EAP7_ZIP=jboss-eap-7.3.0.zip | EAP_PATCH_ZIP=jboss-eap-7.3.*-patch.zip | PAM_ZIP=rhpam-7.9.1-business-central-eap7-deployable.zip  | KIE_ZIP=rhpam-7.9.1-kie-server-ee8.zip  | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.3 | TARGET_TYPE=PAM


### PR DESCRIPTION
#### What is this PR About?
pam-eap-setup updated to handle RHDM.7.10.1

#### How do we test this?
RHDM.7.10.1 should be able to be installed by pam-eap-setp

cc: @redhat-cop/businessautomation-cop
