### PR TITLE
allow project specific URLs for per-project configuration

### DIFF
--- a/extras/bcgithook/scripts/post-commit.sh
+++ b/extras/bcgithook/scripts/post-commit.sh
@@ -177,6 +177,8 @@ REPO_NAME="$PRJ_NAME.git"
 # - newly created projects
 if [[ $(git remote -v | wc -l) -eq 0 ]]; then
   hwd=$(pwd)
+  # is it generic or project specific
+  newRepo="$bburl/$REPO_NAME" && checkurl="${bburl%.git}" && [[ "$checkurl" != "bburl" ]] && newRepo="$bburl"
   newRepo="$bburl/$REPO_NAME" 
   debug "NEW PROJECT ADDING $BBID TO $newRepo"
   git remote add "$BBID" "$newRepo"


### PR DESCRIPTION
#### What is this PR About?
Per-project configuration can now handle project specific URLs.
Previously only generic URLs could be handled which was often a source of confusion.

#### How do we test this?
Git hooks should propagate changes when configured with project specific URL, e.g. 'git@gitlab.com:dundeeinc/delicioushaggis.git' as well as generic ones, e.g. 'git@gitlab.com:dundeeinc''

cc: @redhat-cop/businessautomation-cop
