### PR TITLE
enabled logging of spaces or projects deletion

### DIFF
--- a/deployment-examples/pam-eap-setup/pam-setup.sh
+++ b/deployment-examples/pam-eap-setup/pam-setup.sh
@@ -807,6 +807,7 @@ function applyAdditionalNodeConfig() {
   ncfg+=( "/subsystem=logging/console-handler=CONSOLE/:write-attribute(name=named-formatter,value=COLOR-PATTERN)" )
   ncfg+=( '/subsystem=logging/root-logger=ROOT/:write-attribute(name=handlers,value=["FILE","CONSOLE"])' )
   ncfg+=( "/subsystem=logging/root-logger=ROOT/:write-attribute(name=level,value=INFO)" )
+  ncfg+=( '/subsystem=logging/logger=org.jbpm.workbench.wi.backend.server.workitem.RepositoryStorageVFSImpl/:add(category=org.jbpm.workbench.wi.backend.server.workitem.RepositoryStorageVFSImpl,level=DEBUG)' )
   # CORS
   ncfg+=( '/subsystem=undertow/configuration=filter/response-header=Access-Control-Allow-Origin:add(header-name="Access-Control-Allow-Origin", header-value="*")' )
   ncfg+=( '/subsystem=undertow/server=default-server/host=default-host/filter-ref=Access-Control-Allow-Origin/:add()' )


### PR DESCRIPTION
#### What is this PR About?
Enable logging of projects and spaces deleltion in Business Central configured by pam-eap-setup as per KB6139932

#### How do we test this?
When a project or space is deleted entries in the server.log should be found as per KB6139932

cc: @redhat-cop/businessautomation-cop
