### PR TITLE
added appformer m2 config

### DIFF
--- a/deployment-examples/pam-eap-setup/pam-setup.sh
+++ b/deployment-examples/pam-eap-setup/pam-setup.sh
@@ -605,6 +605,7 @@ function modifyConfiguration() {
   prepareConfigLine "org.uberfire.nio.git.dir"              '${jboss.server.base.dir}/git'
   prepareConfigLine "org.uberfire.metadata.index.dir"       '${jboss.server.base.dir}/metaindex'
   prepareConfigLine "org.guvnor.m2repo.dir"                 '${jboss.server.base.dir}/kie'
+  prepareConfigLine "org.appformer.m2repo.url"              'file:///${jboss.server.base.dir}/kie'
   if [[ "${configOptions[run_mode]}" == "development" ]]; then
     prepareConfigLine "org.guvnor.project.gav.check.disabled" 'true'
     prepareConfigLine "org.kie.server.mode"                   'development'


### PR DESCRIPTION
#### What is this PR About?
Using the embedded in Business Central maven artefact repository without setting the "org.appformer.m2repo.url" results in an error logged without actually preventing BC from operating.
Setting that property prevents the error message logged.

#### How do we test this?
Setting the "org.appformer.m2repo.url" property should prevent the following messages from being logged
WARN  [org.guvnor.m2repo.backend.server.M2RepoServiceImpl] (default task-2) The url null is not valid. Using the default.
ERROR [org.guvnor.m2repo.backend.server.M2RepoServiceImpl] (default task-2) The property org.appformer.m2repo.url is not correctly set. The workbench will use a direct file path to the m2 repository and this should only be used when test the workbench.

cc: @redhat-cop/businessautomation-cop
