### PR TITLE
Deploy Business Central in development mode by default

### DIFF
--- a/deployment-examples/pam-eap-setup/pam-setup.sh
+++ b/deployment-examples/pam-eap-setup/pam-setup.sh
@@ -1098,6 +1098,10 @@ done
 #   option1=value1:option2=value2:
 #
 declare -A configOptions
+# - default to development mode for BC
+tmp="${configOptions[run_mode]}"
+configOptions[run_mode]="development" && [[ "$tmp" == "production" ]] && configOptions[run_mode]="$tmp"
+unset tmp
 if [[ ! -z "$optO" ]]; then
   declare -a multiOptions
   while read -rd:; do multiOptions+=("$REPLY"); done <<<"${optO}:"

--- a/deployment-examples/pam-eap-setup/pam-setup.sh
+++ b/deployment-examples/pam-eap-setup/pam-setup.sh
@@ -1114,10 +1114,7 @@ if [[ ! -z "$optO" ]]; then
     [[ -n "$k" ]] && configOptions["$k"]="${v}"
     unset tmpar
   done
-  tmp="${configOptions[run_mode]}"
-  configOptions[run_mode]="development"
-  [[ "$tmp" == "production" ]] && configOptions[run_mode]="$tmp"
-  unset tmp tmpar multiOptions
+  unset tmpar multiOptions
   [[ "${configOptions[git_hook]}" == "bcgithook" ]] && checkEnv git && checkEnv curl
   [[ "${configOptions[git_hook]}" == "kiegroup" ]] && checkEnv git && checkEnv curl && checkEnv mvn
 fi


### PR DESCRIPTION
#### What is this PR About?
Deploying Business Central using pam-eap-setup does not set development mode unless another option (any option) is specified.
BC should be deployed in development mode by default regardless of other options being present or not.

#### How do we test this?
The "org.kie.server.mode" parameter should be set to "development" without any options specified in the command line

cc: @redhat-cop/businessautomation-cop
