### PR TITLE
updating xstream to non-vulnerable version

### DIFF
--- a/coded-examples/dmn-examples/dmn-jbpm-ext-kjar-example/project/kjars/process-kjar/pom.xml
+++ b/coded-examples/dmn-examples/dmn-jbpm-ext-kjar-example/project/kjars/process-kjar/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.10-java7</version>
+            <version>1.4.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
#### What is this PR About?
updating xstream to non-vulnerable version (1.4.19)

#### How do we test this?
All unit tests should continue to pass

cc: @redhat-cop/businessautomation-cop
