### PR TITLE
Excluding rhpam-charts from shellcheck

### DIFF
--- a/.github/workflows/mvn-deployment-examples-rhpam-charts.yaml
+++ b/.github/workflows/mvn-deployment-examples-rhpam-charts.yaml
@@ -49,7 +49,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: ludeeus/action-shellcheck@master
         env:
-          SHELLCHECK_OPTS: -e SC3043 -e SC2086 -e SC2112 -e SC3059 -e SC2034 -e SC1072 -e SC1056 -e SC1073 -e SC1054 
+          SHELLCHECK_OPTS: -e SC3043 -e SC2086 -e SC2112 -e SC3059 -e SC2034 -e SC1072 -e SC1056 -e SC1073 -e SC1054 -e SC2068 
 
 #        with:
 #          ignore: bcgithook bdd-ui kogito-quick-start-workshop offliner-maven-plugin pam-eap-setup pam-vagrant rhpam-charts

--- a/.github/workflows/mvn-deployment-examples-rhpam-charts.yaml
+++ b/.github/workflows/mvn-deployment-examples-rhpam-charts.yaml
@@ -3,11 +3,11 @@ name: Java CI with Maven for deployment-examples
 on:
   push:
     paths:
-      - .github/workflows/mvn-deployment-examples.yaml
+      - .github/workflows/mvn-deployment-examples-rhpam-charts.yaml
       - deployment-examples/rhpam-charts/**
   pull_request:
     paths:
-      - .github/workflows/mvn-deployment-examples.yaml
+      - .github/workflows/mvn-deployment-examples-rhpam-charts.yaml
       - deployment-examples/rhpam-charts/**
 
 jobs:

--- a/.github/workflows/mvn-deployment-examples-rhpam-charts.yaml
+++ b/.github/workflows/mvn-deployment-examples-rhpam-charts.yaml
@@ -45,11 +45,11 @@ jobs:
           repositories: '[{ "id": "redhat-ga-repository", "url": "https://maven.repository.redhat.com/ga" }]'
           plugin_repositories: '[{ "id": "redhat-ga-repository", "url": "https://maven.repository.redhat.com/ga" }]'
 
-      - name: Run ShellCheck
-        if: matrix.os == 'ubuntu-latest'
-        uses: ludeeus/action-shellcheck@master
-        env:
-          SHELLCHECK_OPTS: -e SC3043 -e SC2086 -e SC2112 -e SC3059 -e SC2034 -e SC1072 -e SC1056 -e SC1073 -e SC1054 -e SC2068 
+#      - name: Run ShellCheck
+#        if: matrix.os == 'ubuntu-latest'
+#        uses: ludeeus/action-shellcheck@master
+#        env:
+#          SHELLCHECK_OPTS: -e SC3043 -e SC2086 -e SC2112 -e SC3059 -e SC2034 -e SC1072 -e SC1056 -e SC1073 -e SC1054 -e SC2068 
 
 #        with:
 #          ignore: bcgithook bdd-ui kogito-quick-start-workshop offliner-maven-plugin pam-eap-setup pam-vagrant rhpam-charts

--- a/.github/workflows/mvn-deployment-examples-rhpam-charts.yaml
+++ b/.github/workflows/mvn-deployment-examples-rhpam-charts.yaml
@@ -1,0 +1,62 @@
+name: Java CI with Maven for deployment-examples
+
+on:
+  push:
+    paths:
+      - .github/workflows/mvn-deployment-examples.yaml
+      - deployment-examples/rhpam-charts/**
+  pull_request:
+    paths:
+      - .github/workflows/mvn-deployment-examples.yaml
+      - deployment-examples/rhpam-charts/**
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Support longpaths
+        if: matrix.os == 'windows-latest'
+        run: git config --system core.longpaths true
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-deployment-examples-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: maven-settings-xml-action
+        uses: whelk-io/maven-settings-xml-action@v4
+        with:
+          repositories: '[{ "id": "redhat-ga-repository", "url": "https://maven.repository.redhat.com/ga" }]'
+          plugin_repositories: '[{ "id": "redhat-ga-repository", "url": "https://maven.repository.redhat.com/ga" }]'
+
+      - name: Run ShellCheck
+        if: matrix.os == 'ubuntu-latest'
+        uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: -e SC3043 -e SC2086 -e SC2112 -e SC3059 -e SC2034 -e SC1072 -e SC1056 -e SC1073 -e SC1054 
+
+#        with:
+#          ignore: bcgithook bdd-ui kogito-quick-start-workshop offliner-maven-plugin pam-eap-setup pam-vagrant rhpam-charts
+
+# Example Mvn Build 
+      # - name: Build deployment-examples/<NEW_PROJECT>
+      #   run: |
+      #     pushd deployment-examples/<NEW_PROJECT>
+      #     mvn -B clean package --no-transfer-progress
+      #     popd

--- a/.github/workflows/mvn-deployment-examples.yaml
+++ b/.github/workflows/mvn-deployment-examples.yaml
@@ -49,7 +49,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: ludeeus/action-shellcheck@master
         with:
-          ignore: bcgithook bdd-ui kogito-quick-start-workshop offliner-maven-plugin pam-eap-setup pam-vagrant
+          ignore: bcgithook bdd-ui kogito-quick-start-workshop offliner-maven-plugin pam-eap-setup pam-vagrant rhpam-charts
 
 # Example Mvn Build 
       # - name: Build deployment-examples/<NEW_PROJECT>

--- a/deployment-examples/rhpam-charts/README.md
+++ b/deployment-examples/rhpam-charts/README.md
@@ -18,6 +18,7 @@ helm install -n my-namespace -f my-rhpam.yaml my-rhpam .
 ```
 
 ## Introduction
+
 This chart provides an Helm-based deployment of RHPAM according to the following requirements:
 * The RH Operators are installed as part of the deployment
 * The authentication is managed by an [RHSSO](https://access.redhat.com/products/red-hat-single-sign-on) instance

--- a/deployment-examples/rhpam-charts/README.md
+++ b/deployment-examples/rhpam-charts/README.md
@@ -1,4 +1,5 @@
 # RHPAM packaged with Helm chart 
+
 This repository holds a configurable Helm chart of [RHPAM](https://developers.redhat.com/products/rhpam/overview), to simplify
 the deployment in the OpenShift environment, exposing the following features:
 * Managed by Red Hat operators
@@ -9,6 +10,7 @@ the deployment in the OpenShift environment, exposing the following features:
 * Git hooks integration (with SSH authentication)
 
 ## TL;DR
+
 ```shell
 git clone https://github.com/redhat-cop/businessautomation-cop.git
 cd businessautomation-cop/deployment-examples/rhpam-charts


### PR DESCRIPTION
#### What is this PR About?
rhpam-charts are excluded from being checked with shellcheck.
rhpam-charts produce helm charts which causes profound confusion to shellcheck being unable to handle helm chart syntax
They have been therefore excluded from being checked with shellcheck until a suitable workaround can be found

#### How do we test this?
github actions should not report errors on rhpam-charts after commits

cc: @redhat-cop/businessautomation-cop
