### PR TITLE
typo in variable was showing wrong value

### DIFF
--- a/deployment-examples/pam-eap-setup/pam-setup.sh
+++ b/deployment-examples/pam-eap-setup/pam-setup.sh
@@ -69,7 +69,7 @@ tmp=$(java -XshowSettings:all -version 2>&1| grep version | grep specification |
 tmp="${tmp#"${tmp%%[![:space:]]*}"}" && tmp="${tmp%"${tmp##*[![:space:]]}"}"
 javaspec="$tmp"
 goon=no && ( [[ "$javaspec" == "1.8" ]] || [[ "$javaspec" == "11" ]] ) && goon=yes
-[[ "$goon" == "no"  ]] && { echo >&2 "ERROR: JAVA VERSION not supported. Please install version 8 or 11, found version $javascped - Aborting"; exit 1; }
+[[ "$goon" == "no"  ]] && { echo >&2 "ERROR: JAVA VERSION not supported. Please install version 8 or 11, found version $javaspec - Aborting"; exit 1; }
 unset tmp javaspec goon
 
 # - check sed version on Mac


### PR DESCRIPTION
#### What is this PR About?
There was a typo in a variable in an echo statement that could result in displaying wrong information.
The actual execution of the script is not impacted, typo is only in an "echo" statement.

#### How do we test this?
Installation should proceed as usual. 


cc: @redhat-cop/businessautomation-cop
