### PR TITLE
added gitbash detection for pam-eap-setup

### DIFF
--- a/deployment-examples/pam-eap-setup/pam-setup.sh
+++ b/deployment-examples/pam-eap-setup/pam-setup.sh
@@ -9,6 +9,7 @@
 #
 # sanity environment check
 CYGWIN_ON=no
+GITBASH_ON=no
 MACOS_ON=no
 LINUX_ON=no
 min_bash_version=4
@@ -21,7 +22,11 @@ if [[ "$CYGWIN_ON" == "yes" ]]; then
   echo "CYGWIN DETECTED - WILL TRY TO ADJUST PATHS"
   min_bash_version=4
 fi
-
+a=$(uname -a) && al=$(echo "$a" | awk '{ print tolower($0); }') && ac=${al#mingw64} && [[ "$al" != "$ac" ]] && CYGWIN_ON=yes && GITBASH_ON=yes
+if [[ "$CYGWIN_ON" == "yes" ]] && [[ "$GITBASH_ON" == "yes" ]]; then
+  echo "GITBASH DETECTED - WILL PRETEND IS CYGWIN - WILL TRY TO ADJUST PATHS"
+  min_bash_version=4
+fi
 # - try to detect MacOS
 a=$(uname) && al=$(echo "$a" | awk '{ print tolower($0); }') && ac=${al%darwin} && [[ "$al" != "$ac" ]] && MACOS_ON=yes
 [[ "$MACOS_ON" == "yes" ]] && min_bash_version=5 && echo "macOS DETECTED"


### PR DESCRIPTION
#### What is this PR About?
Adding gitbash detection for Windows environments. 
Gitbash is a popular alternative to cygwin and shares a lot of functionality.

#### How do we test this?
PAM components should be installing in a gitbash environment in Windows.

cc: @redhat-cop/businessautomation-cop
