### PR TITLE
allow for complex values on system properties

### DIFF
--- a/deployment-examples/pam-eap-setup/pam-setup.sh
+++ b/deployment-examples/pam-eap-setup/pam-setup.sh
@@ -322,7 +322,7 @@ function prepareConfigLine() {
     pamConfigList+=( "if (outcome == success) of /system-property=$key:read-resource" )
     pamConfigList+=( "  /system-property=$key:remove > $TMP_FILE" )
     pamConfigList+=( "end-if" )
-    pamConfigList+=( "/system-property=$key:add(value=$result) > $TMP_FILE" )
+    pamConfigList+=( "/system-property=$key:add(value=\"$result\") > $TMP_FILE" )
   fi
 }
 


### PR DESCRIPTION
#### What is this PR About?
Any number of EAP system properties can be set at install time through the "pam.config" file. Values containing special characters would misconfigure EAP. 
This fix addresses that by enclosing values in quotes.

#### How do we test this?
EAP system properties values containing special characters would not misconfigure EAP

cc: @redhat-cop/businessautomation-cop
