### PR TITLE
Added more kie-app yaml examples

### DIFF
--- a/deployment-examples/operator-yaml/kieapp-rhpam-authoring-with-git-hooks.yaml
+++ b/deployment-examples/operator-yaml/kieapp-rhpam-authoring-with-git-hooks.yaml
@@ -1,0 +1,27 @@
+apiVersion: app.kiegroup.org/v2
+kind: KieApp
+metadata:
+  name: feb25841
+spec:
+  commonConfig:
+    adminPassword: P@ssw0rd
+    adminUser: rhpamAdmin
+  environment: rhpam-authoring
+  useImageTags: true
+  objects:
+    console:
+      gitHooks:
+        mountPath: /opt/kie/data/git/hooks
+        from:
+          kind: ConfigMap
+          name: git-hooks
+      replicas: 1
+    servers:
+      - database:
+          type: h2
+        replicas: 1
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            memory: 1Gi

--- a/deployment-examples/operator-yaml/kieapp-rhpam-authoring-with-git-hooks.yaml
+++ b/deployment-examples/operator-yaml/kieapp-rhpam-authoring-with-git-hooks.yaml
@@ -1,7 +1,7 @@
 apiVersion: app.kiegroup.org/v2
 kind: KieApp
 metadata:
-  name: feb25841
+  name: git-hooks-example
 spec:
   commonConfig:
     adminPassword: P@ssw0rd

--- a/deployment-examples/operator-yaml/kieapp-rhpam-production-immutable-with-nexus.yaml
+++ b/deployment-examples/operator-yaml/kieapp-rhpam-production-immutable-with-nexus.yaml
@@ -1,0 +1,37 @@
+apiVersion: app.kiegroup.org/v2
+kind: KieApp
+metadata:
+  name: immutable-with-nexus-example
+spec:
+  commonConfig:
+    adminPassword: P@ssw0rd
+    adminUser: rhpamAdmin
+  environment: rhpam-production-immutable
+  useImageTags: true
+  objects:
+    servers:
+      - database:
+          type: h2
+        env:
+          - name: MAVEN_REPO_ID
+            value: repo-custom
+          - name: MAVEN_REPO_USERNAME
+            value: admin
+          - name: MAVEN_REPO_PASSWORD
+            value: admin123
+          - name: MAVEN_REPO_URL # repo that contains the kjar that's to be deployed into kie-server
+            value: >-
+              http://nexus-pam-710.apps-crc.testing/repository/pam-mixed/
+          - name: MAVEN_MIRROR_URL # repo that contains all the dependent artifacts required for kie-server to run
+            value: >-
+              http://nexus-pam-710.apps-crc.testing/repository/pam-group/
+          - name: MAVEN_MIRROR_OF
+            value: 'external:*,!repo-custom'
+          - name: KIE_SERVER_CONTAINER_DEPLOYMENT
+            value: 'afps_1.0.3(afps-rules)=com.test.nems:afps-rules:1.0.3'
+        replicas: 1
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            memory: 1Gi


### PR DESCRIPTION
#### What is this PR About?

Added more kie-app yaml examples that cover the following setup requirements:
a.) rhpam authoring with external nexus
b.) rhpam authoring with git-hooks

#### How do we test this?
Could be tested by feeding these yamls to RHBA operator

cc: @redhat-cop/businessautomation-cop
