### PR TITLE
Added RHPAM.7.13.0 support to pam-eap-setup

### DIFF
--- a/deployment-examples/pam-eap-setup/CHANGELOG
+++ b/deployment-examples/pam-eap-setup/CHANGELOG
@@ -1,6 +1,10 @@
 
 # CHANGELOG
 
+-- RELEASE : 29 AUG 2022
+
+PAM: Updated for PAM.7.13.0
+
 -- RELEASE : 24 SEP 2020
 
 PAM: Updated for PAM.7.8.1

--- a/deployment-examples/pam-eap-setup/README.md
+++ b/deployment-examples/pam-eap-setup/README.md
@@ -210,6 +210,7 @@ Depending on PAM version the following files are required:
         | 7.11.1    | rhpam-7.11.1-business-central-eap7-deployable.zip, rhpam-7.11.1-kie-server-ee8.zip  |
         | 7.12.0    | rhpam-7.12.0-business-central-eap7-deployable.zip, rhpam-7.12.0-kie-server-ee8.zip  |
         | 7.12.1    | rhpam-7.12.1-business-central-eap7-deployable.zip, rhpam-7.12.1-kie-server-ee8.zip  |
+        | 7.13.0    | rhpam-7.13.0-business-central-eap7-deployable.zip, rhpam-7.13.0-kie-server-ee8.zip  |
 
         |DM Version| Files                                                                             |
         |----------|-----------------------------------------------------------------------------------|

--- a/deployment-examples/pam-eap-setup/pam-setup.sh
+++ b/deployment-examples/pam-eap-setup/pam-setup.sh
@@ -158,6 +158,7 @@ MASTER_CONFIG=master.conf
 # versions supported
 #
 cat << "__CONFIG" > $MASTER_CONFIG
+PAM7130 | EAP7_ZIP=jboss-eap-7.4.0.zip | EAP_PATCH_ZIP=jboss-eap-7.4.*-patch.zip | PAM_ZIP=rhpam-7.13.0-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.13.0-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.4 | TARGET_TYPE=PAM
 PAM7121 | EAP7_ZIP=jboss-eap-7.4.0.zip | EAP_PATCH_ZIP=jboss-eap-7.4.*-patch.zip | PAM_ZIP=rhpam-7.12.1-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.12.1-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.4 | TARGET_TYPE=PAM
 DM7121  | EAP7_ZIP=jboss-eap-7.4.0.zip | EAP_PATCH_ZIP=jboss-eap-7.4.*-patch.zip | PAM_ZIP=rhdm-7.12.1-decision-central-eap7-deployable.zip  | KIE_ZIP=rhdm-7.12.1-kie-server-ee8.zip  | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.4 | TARGET_TYPE=DM
 PAM7120 | EAP7_ZIP=jboss-eap-7.4.0.zip | EAP_PATCH_ZIP=jboss-eap-7.4.*-patch.zip | PAM_ZIP=rhpam-7.12.0-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.12.0-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.4 | TARGET_TYPE=PAM
@@ -518,7 +519,7 @@ function installUsers() {
     
     elytronUsers=no
     test="$target" && test="${test%?}"
-    if [[ "x$test" == "xPAM712" ]] || [[ "x$test" == "xDM712" ]]; then
+    if [[ "x$test" == "xPAM712" ]] || [[ "x$test" == "xDM712" ]] || [[ "x$test" == "xPAM713" ]]; then
       if [[ "x$pamInstall" == "xcontroller" ]] || [[ "x$pamInstall" == "xboth" ]]; then
         elytronUsers=yes
       fi


### PR DESCRIPTION
#### What is this PR About?
Added support for RHPAM.7.13 to pam-eap-stup

#### How do we test this?
pam-eap-setup should be able to handle RHPAM.7.13 for local installation

cc: @redhat-cop/businessautomation-cop
