### PR TITLE
added support for RHPAM.7.13.1

### DIFF
--- a/deployment-examples/pam-eap-setup/pam-setup.sh
+++ b/deployment-examples/pam-eap-setup/pam-setup.sh
@@ -158,6 +158,7 @@ MASTER_CONFIG=master.conf
 # versions supported
 #
 cat << "__CONFIG" > $MASTER_CONFIG
+PAM7131 | EAP7_ZIP=jboss-eap-7.4.0.zip | EAP_PATCH_ZIP=jboss-eap-7.4.*-patch.zip | PAM_ZIP=rhpam-7.13.1-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.13.1-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.4 | TARGET_TYPE=PAM
 PAM7130 | EAP7_ZIP=jboss-eap-7.4.0.zip | EAP_PATCH_ZIP=jboss-eap-7.4.*-patch.zip | PAM_ZIP=rhpam-7.13.0-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.13.0-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.4 | TARGET_TYPE=PAM
 PAM7121 | EAP7_ZIP=jboss-eap-7.4.0.zip | EAP_PATCH_ZIP=jboss-eap-7.4.*-patch.zip | PAM_ZIP=rhpam-7.12.1-business-central-eap7-deployable.zip | KIE_ZIP=rhpam-7.12.1-kie-server-ee8.zip | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.4 | TARGET_TYPE=PAM
 DM7121  | EAP7_ZIP=jboss-eap-7.4.0.zip | EAP_PATCH_ZIP=jboss-eap-7.4.*-patch.zip | PAM_ZIP=rhdm-7.12.1-decision-central-eap7-deployable.zip  | KIE_ZIP=rhdm-7.12.1-kie-server-ee8.zip  | PAM_PATCH_ZIP= | INSTALL_DIR=jboss-eap-7.4 | TARGET_TYPE=DM
@@ -830,7 +831,8 @@ function modifyConfiguration() {
     cp $EAP_HOME/standalone/configuration/standalone.xml $xmlConfig
     cp $EAP_HOME/standalone/configuration/standalone.xml.backup $EAP_HOME/standalone/configuration/standalone.xml
   fi
-  rm -f "$ADDITIONAL_NODE_CONFIG" $pamConfigFile
+  echo "---- pamConfigFile --- "$pamConfigFile
+  #rm -f "$ADDITIONAL_NODE_CONFIG" $pamConfigFile
   # try to safeguard exposed interfaces
   local dc=2  && [[ "$CYGWIN_ON" == "yes" ]] && dc=3
   l=$(grep -H -n '<interface name="management">' $xmlConfig | head -1 | cut -d':' -f$dc);


### PR DESCRIPTION
#### What is this PR About?
Added support for RHPAM.7.13.1 to pam-eap-setup

#### How do we test this?
Using RHPAM.7.13.1 binaries should install to a local EAP instance

cc: @redhat-cop/businessautomation-cop
